### PR TITLE
Add `tight` opt; fix IndRNN heatmap; more

### DIFF
--- a/see_rnn/visuals_gen.py
+++ b/see_rnn/visuals_gen.py
@@ -165,7 +165,8 @@ def show_features_1D(data, n_rows=None, label_channels=True, equate_axes=True,
         allowed_kwargs = ('scale_width', 'scale_height', 'show_borders',
                           'show_xy_ticks', 'title_mode', 'show_y_zero',
                           'title_fontsize', 'channel_axis', 'dpi', 'tight',
-                          'color', 'annotation_xy', 'annotation_size')
+                          'borderwidth', 'color',
+                          'annotation_xy', 'annotation_size')
         for kwarg in kwargs:
             if kwarg not in allowed_kwargs:
                 raise Exception("unknown kwarg `%s`" % kwarg)

--- a/see_rnn/visuals_rnn.py
+++ b/see_rnn/visuals_rnn.py
@@ -336,12 +336,20 @@ def rnn_heatmap(model, layer_name=None, layer_idx=None, layer=None,
             w_idx = type_idx + direction_idx*(2 + uses_bias)
             matrix_data = data[w_idx]
 
+            is_vector = (len(matrix_data.shape) == 1)
+            if is_vector:
+                matrix_data = np.expand_dims(matrix_data, -1)
+
             nan_txt = _detect_nans(matrix_data)
             if nan_txt is not None:
                 _print_nans(nan_txt, matrix_data, kernel_type, gate_names, rnn_dim)
 
+            aspect = 20 / len(matrix_data) if is_vector else 'auto'
             img = ax.imshow(matrix_data, cmap=cmap, interpolation='nearest',
-                            aspect='auto', vmin=vmin, vmax=vmax)
+                            aspect=aspect, vmin=vmin, vmax=vmax)
+            if is_vector:
+                ax.set_xticks([])
+
             if gate_sep_width != 0:
                 lw = gate_sep_width
                 [ax.axvline(rnn_dim * gate_idx - .5, linewidth=lw, color='k')

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -270,9 +270,9 @@ def test_misc():  # test miscellaneous functionalities
 
     grads = get_layer_gradients(model, x, y, layer_idx=1)
 
-    show_features_1D(grads,    subplot_samples=True)
+    show_features_1D(grads,    subplot_samples=True, tight=True, borderwidth=2)
     show_features_1D(grads[0], subplot_samples=True)
-    show_features_2D(grads.T, n_rows=1.5)
+    show_features_2D(grads.T, n_rows=1.5, tight=True, borderwidth=2)
     show_features_2D(grads.T[:, :, 0])
     rnn_histogram(model, layer_idx=1, show_xy_ticks=[0, 0], equate_axes=2)
     rnn_heatmap(model, layer_idx=1, cmap=None, normalize=True, show_borders=False)


### PR DESCRIPTION
**New features**:

- `show_features_1D` and `show_features_2D` now support `tight` and `borderwidth` specifications, useful when the number of subplots is very large.

**Bug fixes**:

 - `rnn_heatmap` now handles IndRNN's `recurrent_kernel` as a vector, instead of a 2D array