### PR TITLE
Add introspection tools, fix setup configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,65 +2,60 @@ dist: xenial
 language: python
 cache: pip
 python:
-  - "3.6"
+- '3.6'
 env:
   global:
-    - TF_EAGER="0"
-    - TF_KERAS="0"
+  - TF_EAGER="0"
+  - TF_KERAS="0"
   matrix:
-    - TF_VERSION="1.14.0" KERAS_VERSION="2.2.5"
-    - TF_VERSION="1.14.0" KERAS_VERSION="2.2.5" TF_KERAS="1"
-    - TF_VERSION="2.1.0"  KERAS_VERSION="2.3.1" TF_EAGER="1"
-    - TF_VERSION="2.1.0"  KERAS_VERSION="2.3.1"
-    - TF_VERSION="2.1.0"  KERAS_VERSION="2.3.1" TF_KERAS="1"  TF_EAGER="1"
-    - TF_VERSION="2.1.0"  KERAS_VERSION="2.3.1" TF_KERAS="1"  
-
-notifications:
-  email: false
-
-before_install:
-  - chmod +x test.sh
-  - sudo apt-get update
-  - sudo apt-get -y install python-pip
-  - pip install --upgrade pip
-  - pip install pep8
-  - pip install autopep8
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - conda config --set always_yes yes --set changeps1 no
-  - conda install setuptools
-  - conda install conda
-  - conda update --force conda
-  - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-  - source activate test-environment
-  - export LD_LIBRARY_PATH=$HOME/miniconda/envs/test-environment/lib/:$LD_LIBRARY_PATH
-  - pip install -r requirements-test.txt
-  - conda install matplotlib
-  - pip install coveralls
-  
-install:
-  - |
-      if [[ -n "$KERAS_VERSION" ]]; then
-          pip install keras=="$KERAS_VERSION";
-      else
-          pip install keras;
-      fi
-      if [[ -n "$TF_VERSION" ]]; then
-          pip install tensorflow=="$TF_VERSION";
-      else
-          pip install tensorflow;
-      fi
-  
-script:
- - ./test.sh
-
-after_success:
-  # Combine coverage reports from Travis jobs
-  - coverage combine --append
-  - coveralls
-  - codecov
+  - TF_VERSION="1.14.0" KERAS_VERSION="2.2.5"
+  - TF_VERSION="1.14.0" KERAS_VERSION="2.2.5" TF_KERAS="1"
+  - TF_VERSION="2.1.0"  KERAS_VERSION="2.3.1" TF_EAGER="1"
+  - TF_VERSION="2.1.0"  KERAS_VERSION="2.3.1"
+  - TF_VERSION="2.1.0"  KERAS_VERSION="2.3.1" TF_KERAS="1"  TF_EAGER="1"
+  - TF_VERSION="2.1.0"  KERAS_VERSION="2.3.1" TF_KERAS="1"
 notifications:
   webhooks:
-    - https://coveralls.io/webhook
+  - https://coveralls.io/webhook
+before_install:
+- chmod +x test.sh
+- sudo apt-get update
+- sudo apt-get -y install python-pip
+- pip install --upgrade pip
+- pip install pep8
+- pip install autopep8
+- wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+- bash miniconda.sh -b -p $HOME/miniconda
+- export PATH="$HOME/miniconda/bin:$PATH"
+- conda config --set always_yes yes --set changeps1 no
+- conda install setuptools
+- conda install conda
+- conda update --force conda
+- conda info -a
+- conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+- source activate test-environment
+- export LD_LIBRARY_PATH=$HOME/miniconda/envs/test-environment/lib/:$LD_LIBRARY_PATH
+- pip install -r requirements-test.txt
+- conda install matplotlib
+- pip install coveralls
+install:
+- |
+  if [[ -n "$KERAS_VERSION" ]]; then
+      pip install keras=="$KERAS_VERSION";
+  else
+      pip install keras;
+  fi
+  if [[ -n "$TF_VERSION" ]]; then
+      pip install tensorflow=="$TF_VERSION";
+  else
+      pip install tensorflow;
+  fi
+script:
+- "./test.sh"
+after_success:
+- coverage combine --append
+- coveralls
+- codecov
+deploy:
+  password:
+    secure: O5Ttbqnk2n7HSGJyJnMa5xCikKl7ulQIZCfrwGoqRteassJ6lrAyIvd37Z5z6o5R3EXGNzB+Ul4DbIByU0Z3esIZsewIjQglqfkUaW0KwJjWHntFrrlXTcbRWDTxogueMxuofZ0ceBj3CrbWZOdzr+UZlM7ckZZ8hkA6HWmPojBP4xw62f5co4Y60qwSIDA0oRIAWiPNr4JJzT/X162091/13DlVEfr7gnW8zInYv0n56eN4LCLLB2DWQ9PREcglFuP6RtRDZFHAX/kqCJ9bl7EfFRege3blN/Gz7o7ScpRQSELaz1b4qtKi2u/i989YjqxVsW0q/mBcW95fgZ7HjSFQQMT/Z3fE01cZ6l/crdQE+V0qIyI3ncJOLM1lYSxfIVjxnLjwLavxtRWTESSJF9mfgwF7lC50mdE+zMIM9OyajPJSwXJQ+TRT5ukGFEd8g8ZWdAmnLO7aEN8Xvu60nnrBXitNFd5BngjA8x3lioYwCnssvxHKlDZUFl7JYa3XSZN+AGF2eXJRh8de40iEvEuJHVkh/0/OOR0TgpSXWtOLbpNLVdzQLVZujc2GgbVwJxjI1BsYgP1sdQjE2Mg1Ie7LFxbquypAtW5tm4Btw8jdbCpPhykYAOBj+VgizC3xKkAa5QazYW0xkhhw+B9pLZI9xRr8cnoPpKevr32khBc=

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ coverage
 pytest
 pytest-cov
 pycodestyle
+Keras

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
 matplotlib
-Keras
 tensorflow

--- a/rnn_sandbox.py
+++ b/rnn_sandbox.py
@@ -35,7 +35,7 @@ else:
     from keras.models import Model
     from keras.optimizers import Adam
 
-from see_rnn import get_layer_gradients, get_layer_outputs, get_rnn_weights
+from see_rnn import get_gradients, get_outputs, get_rnn_weights
 from see_rnn import features_0D, features_1D, features_2D
 from see_rnn import rnn_heatmap, rnn_histogram
 
@@ -69,7 +69,7 @@ def train_model(model, iterations):
 
 def viz_outs(model, layer_idx=1):
     x, y = make_data(K.int_shape(model.input), model.layers[2].units)
-    outs = get_layer_outputs(model, x, layer_idx=layer_idx)
+    outs = get_outputs(model, x, layer_idx=layer_idx)
 
     features_1D(outs[:1], n_rows=8, show_borders=False)
     features_2D(outs,     n_rows=8, norm=(-1,1))
@@ -81,7 +81,7 @@ def viz_weights(model, layer_idx=1):
 
 def viz_outs_grads(model, layer_idx=1):
     x, y = make_data(K.int_shape(model.input), model.layers[2].units)
-    grads = get_layer_gradients(model, x, y, layer_idx=layer_idx)
+    grads = get_gradients(model, x, y, layer_idx=layer_idx)
     kws = dict(n_rows=8, title_mode='grads')
 
     features_1D(grads[0], show_borders=False, **kws)
@@ -89,7 +89,7 @@ def viz_outs_grads(model, layer_idx=1):
 
 def viz_outs_grads_last(model, layer_idx=2):  # return_sequences=False layer
     x, y = make_data(K.int_shape(model.input), model.layers[2].units)
-    grads = get_layer_gradients(model, x, y, layer_idx=layer_idx)
+    grads = get_gradients(model, x, y, layer_idx=layer_idx)
     features_0D(grads)
 
 def viz_weights_grads(model, layer_idx=1):

--- a/see_rnn/_backend.py
+++ b/see_rnn/_backend.py
@@ -1,0 +1,15 @@
+import os
+from termcolor import colored
+
+
+TF_KERAS = os.environ.get("TF_KERAS", '0') == '1'
+WARN = colored("WARNING:", 'red')
+NOTE = colored("NOTE:", 'blue')
+
+
+if TF_KERAS:
+    import tensorflow.keras.backend as K
+    print(NOTE, "`sample_weights` & `learning_phase` not yet supported "
+          "for `TF_KERAS`, and will be ignored (%s.py)" % __name__)
+else:
+    import keras.backend as K

--- a/see_rnn/inspect_gen.py
+++ b/see_rnn/inspect_gen.py
@@ -1,22 +1,8 @@
-import os
 import numpy as np
 
-from termcolor import colored
 from copy import deepcopy
-from .utils import _validate_args
-
-
-TF_KERAS = os.environ.get("TF_KERAS", '0') == '1'
-WARN = colored("WARNING:", 'red')
-NOTE = colored("NOTE:", 'blue')
-
-
-if TF_KERAS:
-    import tensorflow.keras.backend as K
-    print(NOTE, "`sample_weights` & `learning_phase` not yet supported "
-          "for `TF_KERAS`, and will be ignored (%s.py)" % __name__)
-else:
-    import keras.backend as K
+from .utils import _validate_args, K_eval
+from ._backend import K, TF_KERAS, WARN
 
 
 def get_outputs(model, input_data, layer_name=None, layer_idx=None,
@@ -184,8 +170,8 @@ def get_weights(model, name, as_list=False):
         raise Exception(f"weight w/ name '{name}' not found")
 
     if as_list:
-        return [K.eval(w) for w in weights]
-    return {name: K.eval(w) for name, w in zip(weight_names, weights)}
+        return [K_eval(w) for w in weights]
+    return {name: K_eval(w) for name, w in zip(weight_names, weights)}
 
 
 def _detect_nans(data):
@@ -285,7 +271,7 @@ def weights_norm(model, names, _dict=None, stat_fns=(np.max, np.mean),
             for stat_idx, stat in enumerate(l2_stats):
                 stats_all[l_name][w_idx][stat_idx].append(stat)
 
-        W = [K.eval(w) for w in layer.weights]
+        W = [K_eval(w) for w in layer.weights]
         w_names = [w.name for w in layer.weights]
         l_name = layer.name
 

--- a/see_rnn/inspect_gen.py
+++ b/see_rnn/inspect_gen.py
@@ -124,7 +124,7 @@ def _make_grads_fn(model, layer, mode='outputs'):
     if mode not in ['outputs', 'weights']:
         raise Exception("`mode` must be one of: 'outputs', 'weights'")
 
-    params = layer.output if mode=='outputs' else layer.trainable_weights
+    params = layer.output if mode == 'outputs' else layer.trainable_weights
     grads = model.optimizer.get_gradients(model.total_loss, params)
 
     if TF_KERAS:
@@ -141,20 +141,17 @@ def get_full_layer_name(model, name=None, idx=None):
 
     Arguments:
         model: keras.Model / tf.keras.Model.
-        name: str/None. Layer name. If substring, returns earliest match.
+        name: str/None. Layer name. Returns earliest match.
         idx: int/None. Layer index. Returns model.layers[idx].name
     """
     _validate_args(name, idx, layer=None)
     if idx is not None:
         return model.layers[idx].name
 
-    layer_name = None
     for layer in model.layers:
         if name in layer.name:
-            layer_name = layer.name
-    if layer_name is None:
-        raise Exception(f"layer '{name}' not found")
-    return layer_name
+            return layer.name
+    raise Exception(f"layer '{name}' not found")
 
 
 def get_weights(model, name, as_list=False):
@@ -187,8 +184,8 @@ def get_weights(model, name, as_list=False):
         raise Exception(f"weight w/ name '{name}' not found")
 
     if as_list:
-        return [K.get_value(w) for w in weights]
-    return {name: K.get_value(w) for name, w in zip(weight_names, weights)}
+        return [K.eval(w) for w in weights]
+    return {name: K.eval(w) for name, w in zip(weight_names, weights)}
 
 
 def _detect_nans(data):
@@ -288,7 +285,7 @@ def weights_norm(model, names, _dict=None, stat_fns=(np.max, np.mean),
             for stat_idx, stat in enumerate(l2_stats):
                 stats_all[l_name][w_idx][stat_idx].append(stat)
 
-        W = layer.get_weights()
+        W = [K.eval(w) for w in layer.weights]
         w_names = [w.name for w in layer.weights]
         l_name = layer.name
 

--- a/see_rnn/inspect_gen.py
+++ b/see_rnn/inspect_gen.py
@@ -170,8 +170,8 @@ def get_weights(model, name, as_list=False):
         raise Exception(f"weight w/ name '{name}' not found")
 
     if as_list:
-        return [K_eval(w) for w in weights]
-    return {name: K_eval(w) for name, w in zip(weight_names, weights)}
+        return [K_eval(w, K) for w in weights]
+    return {name: K_eval(w, K) for name, w in zip(weight_names, weights)}
 
 
 def _detect_nans(data):
@@ -271,7 +271,7 @@ def weights_norm(model, names, _dict=None, stat_fns=(np.max, np.mean),
             for stat_idx, stat in enumerate(l2_stats):
                 stats_all[l_name][w_idx][stat_idx].append(stat)
 
-        W = [K_eval(w) for w in layer.weights]
+        W = [K_eval(w, K) for w in layer.weights]
         w_names = [w.name for w in layer.weights]
         l_name = layer.name
 

--- a/see_rnn/inspect_rnn.py
+++ b/see_rnn/inspect_rnn.py
@@ -1,18 +1,6 @@
-import os
-
-from termcolor import colored
-
 from .inspect_gen import get_layer
 from .utils import _validate_args, _validate_rnn_type
-
-TF_KERAS = os.environ.get("TF_KERAS", '0') == '1'
-if TF_KERAS:
-    import tensorflow.keras.backend as K
-else:
-    import keras.backend as K
-
-WARN = colored("WARNING:", 'red')
-NOTE = colored("NOTE:", 'blue')
+from ._backend import K, TF_KERAS, WARN
 
 
 def get_rnn_weights(model, layer_name=None, layer_idx=None, layer=None,

--- a/see_rnn/utils.py
+++ b/see_rnn/utils.py
@@ -122,8 +122,5 @@ def K_eval(x, backend=K):
     try:
         return K.get_value(K.to_dense(x))
     except:
-        try:
-            eval_fn = K.function([], [x])
-            return eval_fn([])[0]
-        except:
-            return K.eager(K.eval)(x)
+        eval_fn = K.function([], [x])
+        return eval_fn([])[0]

--- a/see_rnn/utils.py
+++ b/see_rnn/utils.py
@@ -1,8 +1,5 @@
 import numpy as np
-from termcolor import colored
-
-NOTE = colored("NOTE:", 'blue')
-WARN = colored("WARNING:", 'red')
+from ._backend import WARN, NOTE
 
 
 def _validate_args(layer_name, layer_idx, layer):
@@ -117,3 +114,16 @@ def _rnn_gate_names(rnn_type):
             'SimpleRNN': [''],
             'IndRNN':    [''],
             }[rnn_type]
+
+
+def K_eval(x, backend):
+    """Workaround to TF2.0/2.1-Graph's buggy tensor evaluation"""
+    K = backend
+    try:
+        return K.get_value(K.to_dense(x))
+    except:
+        try:
+            eval_fn = K.function([], [x])
+            return eval_fn([])[0]
+        except:
+            return K.eager(K.eval)(x)

--- a/see_rnn/utils.py
+++ b/see_rnn/utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-from ._backend import WARN, NOTE
+from ._backend import K, WARN, NOTE
 
 
 def _validate_args(layer_name, layer_idx, layer):
@@ -116,7 +116,7 @@ def _rnn_gate_names(rnn_type):
             }[rnn_type]
 
 
-def K_eval(x, backend):
+def K_eval(x, backend=K):
     """Workaround to TF2.0/2.1-Graph's buggy tensor evaluation"""
     K = backend
     try:

--- a/see_rnn/utils.py
+++ b/see_rnn/utils.py
@@ -24,7 +24,7 @@ def _process_rnn_args(model, layer_name, layer_idx, layer, input_data, labels,
        `mode` arg, and fetch various pertinent RNN attributes.
     """
 
-    from .inspect_gen import get_layer, get_layer_gradients
+    from .inspect_gen import get_layer, get_gradients
     from .inspect_rnn import get_rnn_weights
 
     def _validate_args_(layer_name, layer_idx, layer, input_data, labels,
@@ -84,7 +84,7 @@ def _process_rnn_args(model, layer_name, layer_idx, layer, input_data, labels,
             data = get_rnn_weights(model, layer_name, layer_idx,
                                    as_tensors=False, concat_gates=True)
         else:
-            data = get_layer_gradients(model, input_data, labels,
+            data = get_gradients(model, input_data, labels,
                                        layer=layer, mode='weights')
 
     rnn_info = dict(rnn_type=rnn_type, gate_names=gate_names,

--- a/see_rnn/visuals_gen.py
+++ b/see_rnn/visuals_gen.py
@@ -1,10 +1,8 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import cm
-from termcolor import colored
 
-
-NOTE = colored("NOTE:", 'blue')
+from ._backend import NOTE
 
 
 def features_0D(data, marker='o', cmap='bwr', color=None, configs=None, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,17 @@
 import os
 import re
-import codecs
 from setuptools import setup, find_packages
 
 current_path = os.path.abspath(os.path.dirname(__file__))
 
 
 def read_file(*parts):
-    with codecs.open(os.path.join(current_path, *parts), 'r', 'utf8') as reader:
+    with open(os.path.join(current_path, *parts), encoding='utf-8') as reader:
         return reader.read()
 
 
 def get_requirements(*parts):
-    with codecs.open(os.path.join(current_path, *parts), 'r', 'utf8') as reader:
+    with open(os.path.join(current_path, *parts), encoding='utf-8') as reader:
         return list(map(lambda x: x.strip(), reader.readlines()))
 
 
@@ -36,7 +35,7 @@ setup(
     description=('RNN weights, gradients, & activations visualization '
                  'in Keras & TensorFlow'),
     long_description=read_file('README.md'),
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     keywords=(
         "rnn tensorflow keras visualization deep-learning lstm gru "
     ),
@@ -46,7 +45,8 @@ setup(
     tests_require=["pytest>=4.0", "pytest-cov"],
     classifiers=[
         "Programming Language :: Python :: 3.6",
-        "License :: MIT License",
+        "Programming Language :: Python :: 3.7",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Intended Audience :: Developers",
         "Intended Audience :: Education",

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -277,10 +277,8 @@ def test_misc():  # test miscellaneous functionalities
     x, y = make_data(batch_shape, units)
     model.train_on_batch(x, y)
 
-    # problem with TF2.0/2.1 graph in K.get_weights()
-    pass_on_error(weights_norm, model, 'gru', omit_weight_names='bias',
-                   verbose=1)
-    pass_on_error(weights_norm, model, 'gru')
+    weights_norm(model, 'gru', omit_weight_names='bias', verbose=1)
+    weights_norm(model, 'gru')
 
     grads = get_gradients(model, x, y, layer_idx=1)
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -379,7 +379,7 @@ def test_envs():  # pseudo-tests for coverage for different env flags
                            Model=Model)
         model = make_model(_GRU, batch_shape, new_imports=new_imports)
 
-        glg(model, x, y, layer_idx=1)
+        pass_on_error(model, x, y, layer_idx=1)  # possibly _backend-induced err
         pass_on_error(glg, model, x, y, 1)
         rs(model.layers[1])
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -278,19 +278,22 @@ def test_misc():  # test miscellaneous functionalities
     model.train_on_batch(x, y)
 
     weights_norm(model, 'gru', omit_weight_names='bias', verbose=1)
-    weights_norm(model, 'gru')
+    stats = weights_norm(model, 'gru')
+    weights_norm(model, 'gru', _dict=stats)
 
     grads = get_gradients(model, x, y, layer_idx=1)
 
-    features_1D(grads,    subplot_samples=True, tight=True, borderwidth=2)
+    features_1D(grads, subplot_samples=True, tight=True, borderwidth=2,
+                equate_axes=False)
     features_1D(grads[0], subplot_samples=True)
     features_2D(grads.T, n_rows=1.5, tight=True, borderwidth=2)
-    features_2D(grads.T[:, :, 0])
+    features_2D(grads.T[:, :, 0], norm='auto')
     features_hist(grads, show_borders=False, borderwidth=1,
                   show_xy_ticks=[0, 0], title="grads")
-    features_hist_v2(grads[:, :4, :3], show_borders=False, xlims=(-.01, .01),
-                     ylim=100, borderwidth=1, show_xy_ticks=[0, 0],
-                     side_annot='row', title="Grads")
+    features_hist_v2(list(grads[:, :4, :3]), colnames=list('abcd'),
+                     show_borders=False, xlims=(-.01, .01), ylim=100,
+                     borderwidth=1, show_xy_ticks=[0, 0], side_annot='row',
+                     title="Grads")
     rnn_histogram(model, layer_idx=1, show_xy_ticks=[0, 0], equate_axes=2)
     rnn_heatmap(model, layer_idx=1, cmap=None, normalize=True, show_borders=False)
     rnn_heatmap(model, layer_idx=1, cmap=None, norm='auto', absolute_value=True)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -351,13 +351,14 @@ def test_envs():  # pseudo-tests for coverage for different env flags
 
     from importlib import reload
 
-    from see_rnn import inspect_gen, inspect_rnn, utils
+    from see_rnn import inspect_gen, inspect_rnn, utils, _backend
     for flag in ['1', '0']:
         os.environ["TF_KERAS"] = flag
         TF_KERAS = os.environ["TF_KERAS"] == '1'
         reload(inspect_gen)
         reload(inspect_rnn)
         reload(utils)
+        reload(_backend)
         from see_rnn.inspect_gen import get_gradients as glg
         from see_rnn.inspect_rnn import rnn_summary as rs
         from see_rnn.utils import _validate_rnn_type as _vrt

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -355,10 +355,10 @@ def test_envs():  # pseudo-tests for coverage for different env flags
     for flag in ['1', '0']:
         os.environ["TF_KERAS"] = flag
         TF_KERAS = os.environ["TF_KERAS"] == '1'
+        reload(_backend)
+        reload(utils)
         reload(inspect_gen)
         reload(inspect_rnn)
-        reload(utils)
-        reload(_backend)
         from see_rnn.inspect_gen import get_gradients as glg
         from see_rnn.inspect_rnn import rnn_summary as rs
         from see_rnn.utils import _validate_rnn_type as _vrt


### PR DESCRIPTION
**Breaking**:
  - `get_layer_outputs` -> `get_outputs`
  - `get_layer_gradients` -> `get_gradients`

**Bug fixes**:
  - `codecs.open` -> `open`, as former's formatting of `README.md` in `setup.py` was overflowing package build metadata
  - TF 2.0 / 2.1 Graph: use `K_eval` instead of `K.get_value` or `.get_weights` to get layer weights

**Misc**:
  - Created `_backend.py` to move repeated declarations and env vars to
  - Added `K_eval` to `utils.py` (see bugfix bullet 2)
  - Improved docstring for `features_hist_v2`
  - Added `classifiers` in `setup.py`