### PR TITLE
Add universal layer spec, custom features

### DIFF
--- a/rnn_sandbox.py
+++ b/rnn_sandbox.py
@@ -42,16 +42,16 @@ from see_rnn import rnn_heatmap, rnn_histogram
 ###############################################################################
 def make_model(rnn_layer, batch_shape, units=8, bidirectional=False):
     ipt = Input(batch_shape=batch_shape)
-    if bidirectional: 
+    if bidirectional:
         x = Bidirectional(rnn_layer(units, return_sequences=True,))(ipt)
     else:
         x = rnn_layer(units, return_sequences=True)(ipt)
-    out = rnn_layer(units, return_sequences=False)(x)  
+    out = rnn_layer(units, return_sequences=False)(x)
 
     model = Model(ipt, out)
     model.compile(Adam(lr=1e-2), 'mse')
     return model
-    
+
 def make_data(batch_shape, units):
     return (np.random.randn(*batch_shape),
             np.random.uniform(-1, 1, (batch_shape[0], units)))
@@ -81,7 +81,7 @@ def viz_weights(model, idx=1):
 
 def viz_outs_grads(model, idx=1):
     x, y = make_data(K.int_shape(model.input), model.layers[2].units)
-    grads = get_gradients(model, x, y, idx=idx)
+    grads = get_gradients(model, idx, x, y)
     kws = dict(n_rows=8, title_mode='grads')
 
     features_1D(grads[0], show_borders=False, **kws)
@@ -89,20 +89,20 @@ def viz_outs_grads(model, idx=1):
 
 def viz_outs_grads_last(model, idx=2):  # return_sequences=False layer
     x, y = make_data(K.int_shape(model.input), model.layers[2].units)
-    grads = get_gradients(model, x, y, idx=idx)
+    grads = get_gradients(model, idx, x, y)
     features_0D(grads)
 
 def viz_weights_grads(model, idx=1):
     x, y = make_data(K.int_shape(model.input), model.layers[2].units)
-    kws = dict(idx=idx, input_data=x, labels=y)
+    kws = dict(_id=idx, input_data=x, labels=y)
 
     rnn_histogram(model, mode='grads', bins=400, **kws)
     print('\n')
     rnn_heatmap(model,   mode='grads', cmap=None, absolute_value=True, **kws)
 
 def viz_prefetched_data(model, data, idx=1):
-    rnn_histogram(model, idx=idx, data=data)
-    rnn_heatmap(model,   idx=idx, data=data)
+    rnn_histogram(model, idx, data=data)
+    rnn_heatmap(model,   idx, data=data)
 
 ###############################################################################
 units = 64

--- a/rnn_sandbox.py
+++ b/rnn_sandbox.py
@@ -67,42 +67,42 @@ def train_model(model, iterations):
         if i % 40 == 0:
             x, y = make_data(batch_shape, units)
 
-def viz_outs(model, layer_idx=1):
+def viz_outs(model, idx=1):
     x, y = make_data(K.int_shape(model.input), model.layers[2].units)
-    outs = get_outputs(model, x, layer_idx=layer_idx)
+    outs = get_outputs(model, x, idx=idx)
 
     features_1D(outs[:1], n_rows=8, show_borders=False)
     features_2D(outs,     n_rows=8, norm=(-1,1))
 
-def viz_weights(model, layer_idx=1):
-    rnn_histogram(model, layer_idx=layer_idx, mode='weights', bins=400)
+def viz_weights(model, idx=1):
+    rnn_histogram(model, idx=idx, mode='weights', bins=400)
     print('\n')
-    rnn_heatmap(model,   layer_idx=layer_idx, mode='weights', norm='auto')
+    rnn_heatmap(model,   idx=idx, mode='weights', norm='auto')
 
-def viz_outs_grads(model, layer_idx=1):
+def viz_outs_grads(model, idx=1):
     x, y = make_data(K.int_shape(model.input), model.layers[2].units)
-    grads = get_gradients(model, x, y, layer_idx=layer_idx)
+    grads = get_gradients(model, x, y, idx=idx)
     kws = dict(n_rows=8, title_mode='grads')
 
     features_1D(grads[0], show_borders=False, **kws)
     features_2D(grads,    norm=(-1e-4, 1e-4), **kws)
 
-def viz_outs_grads_last(model, layer_idx=2):  # return_sequences=False layer
+def viz_outs_grads_last(model, idx=2):  # return_sequences=False layer
     x, y = make_data(K.int_shape(model.input), model.layers[2].units)
-    grads = get_gradients(model, x, y, layer_idx=layer_idx)
+    grads = get_gradients(model, x, y, idx=idx)
     features_0D(grads)
 
-def viz_weights_grads(model, layer_idx=1):
+def viz_weights_grads(model, idx=1):
     x, y = make_data(K.int_shape(model.input), model.layers[2].units)
-    kws = dict(layer_idx=layer_idx, input_data=x, labels=y)
+    kws = dict(idx=idx, input_data=x, labels=y)
 
     rnn_histogram(model, mode='grads', bins=400, **kws)
     print('\n')
     rnn_heatmap(model,   mode='grads', cmap=None, absolute_value=True, **kws)
 
-def viz_prefetched_data(model, data, layer_idx=1):
-    rnn_histogram(model, layer_idx=layer_idx, data=data)
-    rnn_heatmap(model,   layer_idx=layer_idx, data=data)
+def viz_prefetched_data(model, data, idx=1):
+    rnn_histogram(model, idx=idx, data=data)
+    rnn_heatmap(model,   idx=idx, data=data)
 
 ###############################################################################
 units = 64
@@ -117,5 +117,5 @@ viz_outs_grads_last(model, 2)
 viz_weights(model, 1)
 viz_weights_grads(model, 1)
 
-data = get_rnn_weights(model, layer_idx=1)
+data = get_rnn_weights(model, idx=1)
 viz_prefetched_data(model, data, 1)

--- a/see_rnn/inspect_gen.py
+++ b/see_rnn/inspect_gen.py
@@ -145,7 +145,7 @@ def get_layer(model, _id):
     """Returns layer by index or name.
     If multiple matches are found, returns earliest.
     """
-    names, idxs, _, one_requested = _validate_args(_id, layer=None)
+    names, idxs, _, one_requested = _validate_args(_id)
 
     layers = []
     if idxs is not None:
@@ -182,7 +182,7 @@ def get_full_name(model, _id):
     Returns:
         Full name of layer specified by `_id`.
     """
-    names, idxs, _, one_requested = _validate_args(_id, layer=None)
+    names, idxs, _, one_requested = _validate_args(_id)
 
     fullnames = []
     if idxs is not None:
@@ -269,7 +269,9 @@ def get_weights(model, _id, as_dict=False):
             return _get_by_idx(model, _id)
 
     weights = {}
-    _ids = _id if isinstance(_id, list) else [_id]
+    names, idxs, *_ = _validate_args(_id)
+    _ids = [x for var in (names, idxs) if var for x in var] or None
+
     for _id in _ids:
         weights.update(_get_weights_tensors(model, _id))
 

--- a/see_rnn/inspect_gen.py
+++ b/see_rnn/inspect_gen.py
@@ -27,7 +27,7 @@ def get_outputs(model, _id, input_data, layer=None, learning_phase=0,
     """
     def _get_outs_tensors(model, names, idxs, layers):
         if layers is None:
-            _id = [x for v in (names, idxs) if v for x in v] or None
+            _id = [x for var in (names, idxs) if var for x in var] or None
             layers = get_layer(model, _id)
         if not isinstance(layers, list):
             layers = [layers]
@@ -84,7 +84,7 @@ def get_gradients(model, _id, input_data, labels, layer=None, mode='outputs',
         return _validate_args(_id, layer)
 
     names, idxs, layers, one_requested = _validate_args_(_id, layer, mode)
-    _id = [x for v in (names, idxs) if v for x in v] or None
+    _id = [x for var in (names, idxs) if var for x in var] or None
 
     if layers is None:
         layers = get_layer(model, _id)
@@ -98,8 +98,6 @@ def get_gradients(model, _id, input_data, labels, layer=None, mode='outputs',
 
     if as_dict:
         return {get_full_name(model, i): x for i, x in zip(names or idxs, grads)}
-
-    print("len(grads)", len(grads))
     return grads[0] if (one_requested and len(grads) == 1) else grads
 
 
@@ -201,7 +199,7 @@ def get_weights(model, _id, as_dict=False):
     """
     def _get_weights_tensors(model, _id):
         def _get_by_idx(model, idx):
-            if len(idx) == 2:
+            if isinstance(idx, tuple) and len(idx) == 2:
                 layer_idx, weight_idxs = idx
             else:
                 layer_idx, weight_idxs = idx, None
@@ -292,7 +290,8 @@ def weights_norm(model, _id, _dict=None, stat_fns=(np.max, np.mean),
     """
     def _process_args(model, _id, _dict, omit_weight_names):
         _ids = _id if isinstance(_id, list) else [_id]
-        names = [get_full_name(model, _id) for _id in _ids]
+        names = [get_full_name(model, _id if isinstance(_id, int) else _id[0])
+                 for _id in _ids]
 
         if omit_weight_names is None:
             omit_weight_names = []

--- a/see_rnn/inspect_gen.py
+++ b/see_rnn/inspect_gen.py
@@ -16,6 +16,8 @@ def get_outputs(model, _id, input_data, layer=None, learning_phase=0,
             name: str. Name of layer (full or substring) to be fetched.
                        Returns earliest match if multiple found.
             list of str/int -> treat each str element as name, int as idx.
+                      Ex: ['gru', 2] gets outputs of first layer with name
+                      substring 'gru', then of layer w/ idx 2
         input_data: np.ndarray & supported formats(1). Data w.r.t. which loss is
                to be computed for the gradient. Only for mode=='grads'.
         layer: keras.Layer/tf.keras.Layer. Layer whose outputs to return.
@@ -65,6 +67,8 @@ def get_gradients(model, _id, input_data, labels, layer=None, mode='outputs',
             name: str. Name of layer (full or substring) to be fetched.
                        Returns earliest match if multiple found.
             list of str/int -> treat each str element as name, int as idx.
+                      Ex: ['gru', 2] gets gradients of first layer with name
+                      substring 'gru', then of layer w/ idx 2
         input_data: np.ndarray & supported formats(1). Data w.r.t. which loss is
                to be computed for the gradient.
         labels: np.ndarray & supported formats. Labels w.r.t. which loss is
@@ -178,6 +182,8 @@ def get_full_name(model, _id):
             name: str. Name of layer (full or substring) to be fetched.
                        Returns earliest match if multiple found.
             list of str/int -> treat each str element as name, int as idx.
+                      Ex: ['gru', 2] gets full names of first layer w/ name
+                      substring 'gru', and of layer w/ idx 2.
 
     Returns:
         Full name of layer specified by `_id`.
@@ -220,7 +226,10 @@ def get_weights(model, _id, as_dict=False):
                        Can specify a weight (full or substring) in format
                        {name/weight_name}.
             list of str/int/tuple of int -> treat each str element as name,
-                       int/tuple of int as idx.
+                       int/tuple of int as idx. Ex: ['gru', 2, (3, 1, 2)] gets
+                       weights of first layer with name substring 'gru', then all
+                       weights of layer w/ idx 2, then weights w/ idxs 1 and 2 of
+                       layer w/ idx 3.
         as_dict: bool. True:  return weight fullname-value pairs in a dict
                        False: return weight values as list in order fetched
 

--- a/see_rnn/inspect_gen.py
+++ b/see_rnn/inspect_gen.py
@@ -41,8 +41,10 @@ def get_outputs(model, input_data, name=None, idx=None, layer=None,
 
     outs = outs_fn([input_data, learning_phase])
     if as_dict:
-        return {get_full_name(model, name): out
-                for name, out in zip(names, outs)}
+        if names:
+            return {get_full_name(model, n): o for n, o in zip(names, outs)}
+        else:
+            return {get_full_name(model, idx=i): o for i, o in zip(idxs, outs)}
     return outs[0] if (one_requested and len(outs) == 1) else outs
 
 
@@ -95,7 +97,10 @@ def get_gradients(model, input_data, labels, name=None, idx=None, layer=None,
         grads = grads_fn([input_data, sample_weights, labels, 1])
 
     if as_dict:
-        return {get_full_name(model, n): g for n, g in zip(names, grads)}
+        if names:
+            return {get_full_name(model, n): g for n, g in zip(names, grads)}
+        else:
+            return {get_full_name(model, idx=i): g for i, g in zip(idxs, grads)}
     return grads[0] if (one_requested and len(grads) == 1) else grads
 
 
@@ -161,7 +166,8 @@ def get_full_name(model, name=None, idx=None):
     """
     names, idxs, _, one_requested = _validate_args(name, idx, layer=None)
     if idxs is not None:
-        return [model.layers[i].name for i in idxs]
+        fullnames = [model.layers[i].name for i in idxs]
+        return fullnames[0] if one_requested else fullnames
 
     fullnames = []
     for layer in model.layers:
@@ -173,6 +179,7 @@ def get_full_name(model, name=None, idx=None):
 
     if len(fullnames) == 0:
         raise Exception(f"layer w/ name substring '{name}' not found")
+    print("fullnames", fullnames)
     return fullnames[0] if one_requested else fullnames
 
 

--- a/see_rnn/inspect_rnn.py
+++ b/see_rnn/inspect_rnn.py
@@ -3,26 +3,26 @@ from .utils import _validate_args, _validate_rnn_type
 from ._backend import K, TF_KERAS, WARN
 
 
-def get_rnn_weights(model, layer_name=None, layer_idx=None, layer=None,
-                    as_tensors=False, concat_gates=True):
+def get_rnn_weights(model, name=None, idx=None, layer=None, as_tensors=False,
+                    concat_gates=True):
     """Retrievers RNN layer weights.
 
     Arguments:
         model: keras.Model/tf.keras.Model.
-        layer_idx: int. Index of layer to fetch, via model.layers[layer_idx].
-        layer_name: str. Substring of name of layer to be fetched. Returns
-               earliest match if multiple found.
+        idx: int. Index of layer to fetch, via model.layers[idx].
+        name: str. Name of layer (can be substring) to be fetched. Returns
+              earliest match if multiple found.
         layer: keras.Layer/tf.keras.Layer. Layer whose gradients to return.
-               Overrides `layer_idx` and `layer_name`.
+               Overrides `idx` and `name`.
         as_tensors: If True, returns weight tensors instead of array values.
                NOTE: in Eager, both are returned.
         concat_gates: If True, returns kernel weights are signle concatenated
                matrices, instead of individual per-gate weight lists.
     """
 
-    _validate_args(layer_name, layer_idx, layer)
+    _validate_args(name, idx, layer)
     if layer is None:
-        layer = get_layer(model, layer_name, layer_idx)
+        layer = get_layer(model, name, idx)
     rnn_type = _validate_rnn_type(layer, return_value=True)
     IS_CUDNN = 'CuDNN' in rnn_type
 

--- a/see_rnn/inspect_rnn.py
+++ b/see_rnn/inspect_rnn.py
@@ -3,8 +3,7 @@ from .utils import _validate_args, _validate_rnn_type
 from ._backend import K, TF_KERAS, WARN
 
 
-def get_rnn_weights(model, name=None, idx=None, layer=None, as_tensors=False,
-                    concat_gates=True):
+def get_rnn_weights(model, _id, layer=None, as_tensors=False, concat_gates=True):
     """Retrievers RNN layer weights.
 
     Arguments:
@@ -20,9 +19,12 @@ def get_rnn_weights(model, name=None, idx=None, layer=None, as_tensors=False,
                matrices, instead of individual per-gate weight lists.
     """
 
-    _validate_args(name, idx, layer)
+    names, idxs, *_ = _validate_args(_id, layer)
+    name = names[0] if names is not None else None
+    idx  = idxs[0]  if idxs  is not None else None
+
     if layer is None:
-        layer = get_layer(model, name, idx)
+        layer = get_layer(model, name or idx)
     rnn_type = _validate_rnn_type(layer, return_value=True)
     IS_CUDNN = 'CuDNN' in rnn_type
 

--- a/see_rnn/utils.py
+++ b/see_rnn/utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from ._backend import WARN, NOTE
 
 
-def _validate_args(_id, layer):
+def _validate_args(_id, layer=None):
     def _ensure_list(_id, layer):
         # if None, leave as-is
         _ids, layer = [[x] if not isinstance(x, (list, type(None))) else x

--- a/see_rnn/utils.py
+++ b/see_rnn/utils.py
@@ -140,13 +140,16 @@ def K_eval(x, backend=K):
 
 
 def _filter_duplicates_by_keys(keys, *data):
+    def _second_index(ls, k):
+        return [i for i, x in enumerate(ls) if x == k][1]
+
     collected = []
     for k in keys:
         if k in collected:
             for i in range(len(data)):
-                data[i].pop(keys.index(k))
+                data[i].pop(_second_index(keys, k))
             keys.pop(keys.index(k))
-            collected.append(k)
+        collected.append(k)
     if isinstance(data, tuple) and len(data) == 1:
         data = data[0]
     return keys, data

--- a/see_rnn/utils.py
+++ b/see_rnn/utils.py
@@ -6,12 +6,29 @@ from ._backend import K, WARN, NOTE
 def _validate_args(_id, layer):
     def _ensure_list(_id, layer):
         # if None, leave as-is
-        _id, layer = [[x] if not isinstance(x, (list, type(None))) else x
-                      for x in (_id, layer)]
+        _ids, layer = [[x] if not isinstance(x, (list, type(None))) else x
+                       for x in (_id, layer)]
         # ensure external lists unaffected
-        _id, layer = [x.copy() if isinstance(x, list) else x
-                      for x in (_id, layer)]
-        return _id, layer
+        _ids, layer = [x.copy() if isinstance(x, list) else x
+                       for x in (_ids, layer)]
+        return _ids, layer
+
+    def _ids_to_names_and_idxs(_ids):
+        names, idxs = [], []
+        for _id in _ids:
+            if not isinstance(_id, (str, int, tuple)):
+                tp = type(_id).__name__
+                raise ValueError("unsupported _id list element type: %s" % tp
+                                 + "; supported are: str, int, tuple")
+            if isinstance(_id, str):
+                names.append(_id)
+            else:
+                if isinstance(_id, int):
+                    idxs.append(_id)
+                else:
+                    assert all(isinstance(x, int) for x in _id)
+                    idxs.append(_id)
+        return names or None, idxs or None
 
     def _one_requested(_ids, layer):
         return len(layer or _ids) == 1  # give `layer` precedence
@@ -23,8 +40,7 @@ def _validate_args(_id, layer):
     if _ids is None:
         names, idxs = None, None
     else:
-        names = _ids if isinstance(_ids[0], str) else None
-        idxs  = _ids if isinstance(_ids[0], int) else None
+        names, idxs = _ids_to_names_and_idxs(_ids)
     return names, idxs, layer, _one_requested(_ids, layer)
 
 

--- a/see_rnn/utils.py
+++ b/see_rnn/utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 from pathlib import Path
-from ._backend import K, WARN, NOTE
+from ._backend import WARN, NOTE
 
 
 def _validate_args(_id, layer):
@@ -142,16 +142,6 @@ def _rnn_gate_names(rnn_type):
             }[rnn_type]
 
 
-def K_eval(x, backend=K):
-    """Workaround to TF2.0/2.1-Graph's buggy tensor evaluation"""
-    K = backend
-    try:
-        return K.get_value(K.to_dense(x))
-    except Exception as e:
-        eval_fn = K.function([], [x])
-        return eval_fn([])[0]
-
-
 def _filter_duplicates_by_keys(keys, *data):
     def _second_index(ls, k):
         return [i for i, x in enumerate(ls) if x == k][1]
@@ -166,6 +156,7 @@ def _filter_duplicates_by_keys(keys, *data):
     if isinstance(data, tuple) and len(data) == 1:
         data = data[0]
     return keys, data
+
 
 def _save_rnn_fig(figs, savepath, kwargs):
     if len(figs) == 1:

--- a/see_rnn/visuals_gen.py
+++ b/see_rnn/visuals_gen.py
@@ -28,8 +28,8 @@ def features_0D(data, marker='o', cmap='bwr', color=None, configs=None, **kwargs
     kwargs:
         w: float. Scale width  of resulting plot by a factor.
         h: float. Scale height of resulting plot by a factor.
-        show_borders:  bool.  If True, shows boxes around plot(s).
-        title_mode:    bool/str. If True, shows generic supertitle.
+        show_borders: bool.  If True, shows boxes around plot(s).
+        title_mode:   bool/str. If True, shows generic supertitle.
               If str in ('grads', 'outputs'), shows supertitle tailored to
               `data` dim (2D/3D). If other str, shows `title_mode` as supertitle.
               If False, no title is shown.
@@ -38,6 +38,9 @@ def features_0D(data, marker='o', cmap='bwr', color=None, configs=None, **kwargs
                sets both lims to max of abs(`data`) (such that y=0 is centered).
         savepath: str/None. Path to save resulting figure to. Also see `configs`.
                If None, doesn't save.
+
+    Returns:
+        (figs, axes) of generated plots.
     """
 
     w, h         = kwargs.get('w', 1), kwargs.get('h', 1)
@@ -108,11 +111,12 @@ def features_0D(data, marker='o', cmap='bwr', color=None, configs=None, **kwargs
     if not show_borders:
         plt.box(None)
 
-    fig = plt.gcf()
+    fig, axes = plt.gcf(), plt.gca()
     fig.set_size_inches(12 * w, 4 * h)
     plt.show()
     if savepath is not None:
         fig.savefig(savepath, **kw['save'])
+    return fig, axes
 
 
 def features_1D(data, n_rows=None, label_channels=True, equate_axes=True,
@@ -139,6 +143,7 @@ def features_1D(data, n_rows=None, label_channels=True, equate_axes=True,
             'title':   passed to plt.suptitle()
             'tight':   passed to plt.subplots_adjust()
             'annot':   passed to ax.annotate(); ax = subplots axis
+            'save':    passed to fig.savefig() if `savepath` is not None.
 
     iter == list/tuple (both work)
     kwargs:
@@ -159,6 +164,11 @@ def features_1D(data, n_rows=None, label_channels=True, equate_axes=True,
               specifying curve colors in order of drawing. If str/ float iter,
               draws all curves in one color. If None, default coloring is used.
               Ex: ['red', 'blue']; [[0., .8, 1.], [.2, .5, 0.]] (RGB)
+        savepath: str/None. Path to save resulting figure to. Also see `configs`.
+               If None, doesn't save.
+
+    Returns:
+        (figs, axes) of generated plots.
     """
 
     w, h          = kwargs.get('w', 1), kwargs.get('h', 1)
@@ -269,7 +279,7 @@ def features_1D(data, n_rows=None, label_channels=True, equate_axes=True,
 
     if title_mode:
         title = _get_title(data, title_mode, subplot_samples)
-        plt.suptitle(title, **kw['title'])
+        fig.suptitle(title, **kw['title'])
 
     for ax_idx, ax in enumerate(axes.flat):
         if show_y_zero:
@@ -283,7 +293,7 @@ def features_1D(data, n_rows=None, label_channels=True, equate_axes=True,
                     xmax=len(feature_outputs[0]))
 
     if tight:
-        plt.subplots_adjust(**kw['tight'])
+        fig.subplots_adjust(**kw['tight'])
     if borderwidth is not None:
         for ax in axes.flat:
             [s.set_linewidth(borderwidth) for s in ax.spines.values()]
@@ -291,11 +301,11 @@ def features_1D(data, n_rows=None, label_channels=True, equate_axes=True,
     plt.show()
     if savepath is not None:
         fig.savefig(savepath, **kw['save'])
+    return fig, axes
 
 
 def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
-                timesteps_xaxis=True, max_timesteps=None,
-                configs=None, **kwargs):
+                timesteps_xaxis=True, max_timesteps=None, configs=None, **kwargs):
     """Plots 2D heatmaps in a standalone graph or subplot grid.
 
     iter == list/tuple (both work)
@@ -326,6 +336,7 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
             'title':    passed to plt.suptitle()
             'tight':    passed to plt.subplots_adjust()
             'colorbar': passed to fig.colorbar(); fig = subplots figure
+            'save':     passed to fig.savefig() if `savepath` is not None.
 
     kwargs:
         w: float. Scale width  of resulting plot by a factor.
@@ -344,17 +355,22 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
               -1 --> (samples,  timesteps, channels)
               0  --> (channels, timesteps, samples)
         borderwidth: float / None. Width of subplot borders.
+        savepath: str/None. Path to save resulting figure to. Also see `configs`.
+               If None, doesn't save.
+
+    Returns:
+        (figs, axes) of generated plots.
     """
 
-    w, h           = kwargs.get('w', 1), kwargs.get('h', 1)
-    show_borders   = kwargs.get('show_borders', True)
-    show_xy_ticks  = kwargs.get('show_xy_ticks', [1, 1])
-    show_colorbar  = kwargs.get('show_colorbar', False)
-    title_mode     = kwargs.get('title_mode', 'outputs')
-    tight          = kwargs.get('tight', False)
-    channel_axis   = kwargs.get('channel_axis', -1)
-    borderwidth    = kwargs.get('borderwidth', None)
-    savepath       = kwargs.get('savepath', None)
+    w, h          = kwargs.get('w', 1), kwargs.get('h', 1)
+    show_borders  = kwargs.get('show_borders', True)
+    show_xy_ticks = kwargs.get('show_xy_ticks', [1, 1])
+    show_colorbar = kwargs.get('show_colorbar', False)
+    title_mode    = kwargs.get('title_mode', 'outputs')
+    tight         = kwargs.get('tight', False)
+    channel_axis  = kwargs.get('channel_axis', -1)
+    borderwidth   = kwargs.get('borderwidth', None)
+    savepath      = kwargs.get('savepath', None)
 
     def _process_configs(configs, w, h, tight):
         defaults = {
@@ -453,7 +469,7 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
 
     if title_mode:
         title = _get_title(data, title_mode, timesteps_xaxis, vmin, vmax)
-        plt.suptitle(title, **kw['title'])
+        fig.suptitle(title, **kw['title'])
 
     for ax_idx, ax in enumerate(axes.flat):
         img = ax.imshow(data[ax_idx], cmap=cmap, vmin=vmin, vmax=vmax,
@@ -463,7 +479,7 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
     if show_colorbar:
         fig.colorbar(img, ax=axes.ravel().tolist(), **kw['colorbar'])
     if tight:
-        plt.subplots_adjust(**kw['tight'])
+        fig.subplots_adjust(**kw['tight'])
     if borderwidth is not None:
         for ax in axes.flat:
             [s.set_linewidth(borderwidth) for s in ax.spines.values()]
@@ -471,6 +487,7 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
     plt.show()
     if savepath is not None:
         fig.savefig(savepath, **kw['save'])
+    return fig, axes
 
 
 def _get_nrows_and_ncols(n_rows, n_subplots):
@@ -506,6 +523,7 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
             'title':   passed to plt.suptitle()
             'tight':   passed to plt.subplots_adjust()
             'annot':   passed to ax.annotate(); ax = subplots axis
+            'save':    passed to fig.savefig() if `savepath` is not None.
 
     kwargs:
         w: float. Scale width  of resulting plot by a factor.
@@ -521,6 +539,11 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
              list of str: annotate by indexing into the list.
                           If len(list) < len(data), won't annotate remainder.
              None: don't annotate.
+        savepath: str/None. Path to save resulting figure to. Also see `configs`.
+               If None, doesn't save.
+
+    Returns:
+        (figs, axes) of generated plots.
     """
     w, h          = kwargs.get('w', 1), kwargs.get('h', 1)
     show_borders  = kwargs.get('show_borders', True)
@@ -538,7 +561,7 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
             'tight':   dict(left=0, right=1, bottom=0, top=1, wspace=0, hspace=0),
             'annot':   dict(weight='bold', fontsize=14, xy=(.02, .7),
                             xycoords='axes fraction', color='g'),
-            'save':   dict(),
+            'save': dict(),
             }
         configs = configs or {}
         # override defaults, but keep those not in `configs`
@@ -586,7 +609,7 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
     fig, axes = plt.subplots(n_rows, n_cols, **kw['subplot'])
     axes = np.asarray(axes)
     if title is not None:
-        plt.suptitle(title, **kw['title'])
+        fig.suptitle(title, **kw['title'])
 
     for ax_idx, ax in enumerate(axes.flat):
         ax.hist(np.asarray(data[ax_idx]).ravel(), bins=bins, **kw['plot'])
@@ -596,7 +619,7 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
         ax.set_xlim(*xlims)
 
     if tight:
-        plt.subplots_adjust(**kw['tight'])
+        fig.subplots_adjust(**kw['tight'])
     if borderwidth is not None:
         for ax in axes.flat:
             [s.set_linewidth(borderwidth) for s in ax.spines.values()]
@@ -604,6 +627,7 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
     plt.show()
     if savepath is not None:
         fig.savefig(savepath, **kw['save'])
+    return fig, axes
 
 
 def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
@@ -635,6 +659,7 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
             'tight':      passed to plt.subplots_adjust()
             'colnames':   passed to ax.set_title(); ax = subplots axis
             'side_annot': passed to ax.annotate();  ax = subplots axis
+            'save':       passed to fig.savefig() if `savepath` is not None.
 
     kwargs:
         w: float. Scale width  of resulting plot by a factor.
@@ -645,6 +670,11 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
         show_xy_ticks: int/bool iter. Slot 0 -> x, Slot 1 -> y.
         title: str/None. If not None, show `title` as plt.suptitle.
         borderwidth: float / None. Width of subplot borders.
+        savepath: str/None. Path to save resulting figure to. Also see `configs`.
+               If None, doesn't save.
+
+    Returns:
+        (figs, axes) of generated plots.
     """
     w, h          = kwargs.get('w', 1), kwargs.get('h', 1)
     show_borders  = kwargs.get('show_borders', True)
@@ -656,8 +686,7 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
     def _process_configs(configs, w, h):
         defaults = {
             'plot':    dict(),
-            'subplot': dict(sharex='col', sharey=True, dpi=76,
-                            figsize=(10, 10)),
+            'subplot': dict(sharex='col', sharey=True, dpi=76, figsize=(10, 10)),
             'title':   dict(weight='bold', fontsize=15, y=1.06),
             'tight':   dict(left=0, right=1, bottom=0, top=1,
                             wspace=.05, hspace=.05),
@@ -713,7 +742,7 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
 
     fig, axes = plt.subplots(len(data), len(data[0]), **kw['subplot'])
     if title is not None:
-        plt.suptitle(title, **kw['title'])
+        fig.suptitle(title, **kw['title'])
 
     for row in range(n_rows):
         for col in range(n_cols):
@@ -726,7 +755,7 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
     if ylim is not None:
         ax.set_ylim(0, ylim)
     if tight:
-        plt.subplots_adjust(**kw['tight'])
+        fig.subplots_adjust(**kw['tight'])
     if borderwidth is not None:
         for ax in axes.flat:
             [s.set_linewidth(borderwidth) for s in ax.spines.values()]
@@ -734,3 +763,4 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
     plt.show()
     if savepath is not None:
         fig.savefig(savepath, **kw['save'])
+    return fig, axes

--- a/see_rnn/visuals_gen.py
+++ b/see_rnn/visuals_gen.py
@@ -248,7 +248,7 @@ def features_1D(data, n_rows=None, annotations='auto', equate_axes=True,
             n_colors = len(data) if data.ndim == 3 else 1
             color = [None] * n_colors
         if annotations == 'auto':
-            annotations = list(map(str, range(len(data))))
+            annotations = list(map(str, range(n_subplots)))
         elif annotations is not None:
             # ensure external list is unaffected
             annotations = annotations.copy()
@@ -596,7 +596,7 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
             n_rows, n_cols = _get_nrows_and_ncols(n_rows, n_subplots)
 
         if annotations == 'auto':
-            annotations = list(map(str, range(len(data))))
+            annotations = list(map(str, range(n_subplots)))
         elif annotations is not None:
             # ensure external list is unaffected
             annotations = annotations.copy()

--- a/see_rnn/visuals_gen.py
+++ b/see_rnn/visuals_gen.py
@@ -62,7 +62,7 @@ def features_0D(data, marker='o', cmap='bwr', color=None, configs=None, **kwargs
 
     def _catch_unknown_kwargs(kwargs):
         allowed_kwargs = ('w', 'h', 'show_borders', 'title_mode', 'show_y_zero',
-                          'ylims')
+                          'ylims', 'savepath')
         for kwarg in kwargs:
             if kwarg not in allowed_kwargs:
                 raise Exception("unknown kwarg `%s`" % kwarg)
@@ -196,7 +196,7 @@ def features_1D(data, n_rows=None, label_channels=True, equate_axes=True,
     def _catch_unknown_kwargs(kwargs):
         allowed_kwargs = ('w', 'h', 'show_borders', 'show_xy_ticks',
                           'title_mode', 'show_y_zero', 'tight',
-                          'borderwidth', 'color')
+                          'borderwidth', 'color', 'savepath')
         for kwarg in kwargs:
             if kwarg not in allowed_kwargs:
                 raise Exception("unknown kwarg `%s`" % kwarg)
@@ -378,7 +378,7 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
     def _catch_unknown_kwargs(kwargs):
         allowed_kwargs = ('w', 'h', 'show_borders', 'show_xy_ticks',
                           'show_colorbar', 'title_mode', 'tight',
-                          'channel_axis', 'borderwidth')
+                          'channel_axis', 'borderwidth', 'savepath')
         for kwarg in kwargs:
             if kwarg not in allowed_kwargs:
                 raise Exception("unknown kwarg `%s`" % kwarg)
@@ -538,7 +538,7 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
             'tight':   dict(left=0, right=1, bottom=0, top=1, wspace=0, hspace=0),
             'annot':   dict(weight='bold', fontsize=14, xy=(.02, .7),
                             xycoords='axes fraction', color='g'),
-            'sasve':   dict(),
+            'save':   dict(),
             }
         configs = configs or {}
         # override defaults, but keep those not in `configs`
@@ -552,7 +552,7 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
 
     def _catch_unknown_kwargs(kwargs):
         allowed_kwargs = ('w', 'h', 'show_borders', 'show_xy_ticks', 'title',
-                          'borderwidth', 'annotations')
+                          'borderwidth', 'annotations', 'savepath')
         for kwarg in kwargs:
             if kwarg not in allowed_kwargs:
                 raise Exception("unknown kwarg `%s`" % kwarg)
@@ -678,7 +678,7 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
 
     def _catch_unknown_kwargs(kwargs):
         allowed_kwargs = ('w', 'h', 'show_borders', 'show_xy_ticks', 'title',
-                          'borderwidth')
+                          'borderwidth', 'savepath')
         for kwarg in kwargs:
             if kwarg not in allowed_kwargs:
                 raise Exception("unknown kwarg `%s`" % kwarg)

--- a/see_rnn/visuals_gen.py
+++ b/see_rnn/visuals_gen.py
@@ -23,6 +23,7 @@ def features_0D(data, marker='o', cmap='bwr', color=None, configs=None, **kwargs
         configs: dict. kwargs to customize various plot schemes:
             'plot':  passed to plt.scatter()
             'title': passed to plt.suptitle()
+            'save':  passed to fig.savefig() if `savepath` is not None.
 
     kwargs:
         w: float. Scale width  of resulting plot by a factor.
@@ -35,18 +36,22 @@ def features_0D(data, marker='o', cmap='bwr', color=None, configs=None, **kwargs
         show_y_zero: bool. If True, draws y=0.
         ylims: str ('auto'); float list/tuple. Plot y-limits; if 'auto',
                sets both lims to max of abs(`data`) (such that y=0 is centered).
+        savepath: str/None. Path to save resulting figure to. Also see `configs`.
+               If None, doesn't save.
     """
 
     w, h         = kwargs.get('w', 1), kwargs.get('h', 1)
     show_borders = kwargs.get('show_borders', False)
-    title_mode   = kwargs.get('title_mode',   'outputs')
-    show_y_zero  = kwargs.get('show_y_zero',  True)
+    title_mode   = kwargs.get('title_mode', 'outputs')
+    show_y_zero  = kwargs.get('show_y_zero', True)
     ylims        = kwargs.get('ylims', 'auto')
+    savepath     = kwargs.get('savepath', None)
 
     def _process_configs(configs, w, h):
         defaults = {
             'plot':  dict(s=15, linewidth=2),
             'title': dict(weight='bold', fontsize=14),
+            'save':  dict(),
             }
         configs = configs or {}
         # override defaults, but keep those not in `configs`
@@ -102,8 +107,12 @@ def features_0D(data, marker='o', cmap='bwr', color=None, configs=None, **kwargs
         plt.title(title, **kw['title'])
     if not show_borders:
         plt.box(None)
-    plt.gcf().set_size_inches(12 * w, 4 * h)
+
+    fig = plt.gcf()
+    fig.set_size_inches(12 * w, 4 * h)
     plt.show()
+    if savepath is not None:
+        fig.savefig(savepath, **kw['save'])
 
 
 def features_1D(data, n_rows=None, label_channels=True, equate_axes=True,
@@ -160,6 +169,7 @@ def features_1D(data, n_rows=None, label_channels=True, equate_axes=True,
     tight         = kwargs.get('tight', False)
     borderwidth   = kwargs.get('borderwidth', None)
     color         = kwargs.get('color', None)
+    savepath      = kwargs.get('savepath', None)
 
     def _process_configs(configs, w, h, tight, equate_axes):
         defaults = {
@@ -168,7 +178,8 @@ def features_1D(data, n_rows=None, label_channels=True, equate_axes=True,
             'title':   dict(weight='bold', fontsize=14, y=.93 + .12 * tight),
             'tight':   dict(left=0, right=1, bottom=0, top=1, wspace=0, hspace=0),
             'annot':   dict(weight='bold', fontsize=16, color='g',
-                            xy=(.03, .9), xycoords='axes fraction')
+                            xy=(.03, .9), xycoords='axes fraction'),
+            'save':    dict(),
             }
         configs = configs or {}
         # override defaults, but keep those not in `configs`
@@ -276,7 +287,10 @@ def features_1D(data, n_rows=None, label_channels=True, equate_axes=True,
     if borderwidth is not None:
         for ax in axes.flat:
             [s.set_linewidth(borderwidth) for s in ax.spines.values()]
+
     plt.show()
+    if savepath is not None:
+        fig.savefig(savepath, **kw['save'])
 
 
 def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
@@ -340,6 +354,7 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
     tight          = kwargs.get('tight', False)
     channel_axis   = kwargs.get('channel_axis', -1)
     borderwidth    = kwargs.get('borderwidth', None)
+    savepath       = kwargs.get('savepath', None)
 
     def _process_configs(configs, w, h, tight):
         defaults = {
@@ -348,6 +363,7 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
             'title':   dict(weight='bold', fontsize=14, y=.93 + .12 * tight),
             'tight':   dict(left=0, right=1, bottom=0, top=1, wspace=0, hspace=0),
             'colorbar': dict(),
+            'save':     dict(),
             }
         configs = configs or {}
         # override defaults, but keep those not in `configs`
@@ -451,7 +467,10 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
     if borderwidth is not None:
         for ax in axes.flat:
             [s.set_linewidth(borderwidth) for s in ax.spines.values()]
+
     plt.show()
+    if savepath is not None:
+        fig.savefig(savepath, **kw['save'])
 
 
 def _get_nrows_and_ncols(n_rows, n_subplots):
@@ -509,6 +528,7 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
     title         = kwargs.get('title', None)
     borderwidth   = kwargs.get('borderwidth', None)
     annotations   = kwargs.get('annotations', 'auto')
+    savepath      = kwargs.get('savepath', None)
 
     def _process_configs(configs, w, h, tight):
         defaults = {
@@ -518,6 +538,7 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
             'tight':   dict(left=0, right=1, bottom=0, top=1, wspace=0, hspace=0),
             'annot':   dict(weight='bold', fontsize=14, xy=(.02, .7),
                             xycoords='axes fraction', color='g'),
+            'sasve':   dict(),
             }
         configs = configs or {}
         # override defaults, but keep those not in `configs`
@@ -579,7 +600,10 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
     if borderwidth is not None:
         for ax in axes.flat:
             [s.set_linewidth(borderwidth) for s in ax.spines.values()]
+
     plt.show()
+    if savepath is not None:
+        fig.savefig(savepath, **kw['save'])
 
 
 def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
@@ -627,6 +651,7 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
     show_xy_ticks = kwargs.get('show_xy_ticks', [1, 1])
     title         = kwargs.get('title', None)
     borderwidth   = kwargs.get('borderwidth', None)
+    savepath      = kwargs.get('savepath', None)
 
     def _process_configs(configs, w, h):
         defaults = {
@@ -639,6 +664,7 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
             'colnames':   dict(weight='bold', fontsize=14),
             'side_annot': dict(weight='bold', fontsize=14,
                                xy=(1.02, .5), xycoords='axes fraction'),
+            'save': dict(),
             }
         configs = configs or {}
         # override defaults, but keep those not in `configs`
@@ -704,4 +730,7 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
     if borderwidth is not None:
         for ax in axes.flat:
             [s.set_linewidth(borderwidth) for s in ax.spines.values()]
+
     plt.show()
+    if savepath is not None:
+        fig.savefig(savepath, **kw['save'])

--- a/see_rnn/visuals_rnn.py
+++ b/see_rnn/visuals_rnn.py
@@ -78,7 +78,8 @@ def rnn_histogram(model, name=None, idx=None, layer=None, input_data=None,
         return kw
 
     def _catch_unknown_kwargs(kwargs):
-        allowed_kwargs = ('w', 'h', 'show_borders', 'show_xy_ticks', 'bins')
+        allowed_kwargs = ('w', 'h', 'show_borders', 'show_xy_ticks', 'bins',
+                          'savepath')
         for kwarg in kwargs:
             if kwarg not in allowed_kwargs:
                 raise Exception("unknown kwarg `%s`" % kwarg)
@@ -315,7 +316,7 @@ def rnn_heatmap(model, name=None, idx=None, layer=None, input_data=None,
     def _catch_unknown_kwargs(kwargs):
         allowed_kwargs = ('w', 'h', 'show_borders', 'show_colorbar',
                           'show_bias', 'gate_sep_width', 'normalize',
-                          'absolute_value')
+                          'absolute_value', 'savepath')
         for kwarg in kwargs:
             if kwarg not in allowed_kwargs:
                 raise Exception("unknown kwarg `%s`" % kwarg)

--- a/see_rnn/visuals_rnn.py
+++ b/see_rnn/visuals_rnn.py
@@ -15,9 +15,10 @@ def rnn_histogram(model, _id, layer=None, input_data=None, labels=None,
 
     Arguments:
         model: keras.Model/tf.keras.Model.
-        idx: int. Index of layer to fetch, via model.layers[idx].
-        name: str. Name of layer (can be substring) to be fetched. Returns
-              earliest match if multiple found.
+        _id: str/int. int -> idx; str -> name
+            idx: int. Index of layer to fetch, via model.layers[idx].
+            name: str. Name of layer (full or substring) to be fetched.
+                       Returns earliest match if multiple found.
         layer: keras.Layer/tf.keras.Layer. Layer whose gradients to return.
                Overrides `idx` and `name`
         input_data: np.ndarray & supported formats(1). Data w.r.t. which loss is
@@ -260,9 +261,10 @@ def rnn_heatmap(model, _id, layer=None, input_data=None, labels=None,
 
     Arguments:
         model: keras.Model/tf.keras.Model.
-        idx: int. Index of layer to fetch, via model.layers[idx].
-        name: str. Name of layer (can be substring) to be fetched. Returns
-              earliest match if multiple found.
+        _id: str/int. int -> idx; str -> name
+            idx: int. Index of layer to fetch, via model.layers[idx].
+            name: str. Name of layer (full or substring) to be fetched.
+                       Returns earliest match if multiple found.
         layer: keras.Layer/tf.keras.Layer. Layer whose gradients to return.
                Overrides `idx` and `name`
         input_data: np.ndarray & supported formats(1). Data w.r.t. which loss is

--- a/see_rnn/visuals_rnn.py
+++ b/see_rnn/visuals_rnn.py
@@ -480,8 +480,6 @@ def rnn_heatmap(model, name=None, idx=None, layer=None, input_data=None,
         if is_vector:
             plt.subplots_adjust(right=.7, wspace=-.4)
         if show_colorbar:
-            print(axes.shape)
-            print(axes[0, :])
             fig.colorbar(img, ax=axes[0, :], **kw['colorbar'])
 
         if d['uses_bias'] and show_bias:

--- a/see_rnn/visuals_rnn.py
+++ b/see_rnn/visuals_rnn.py
@@ -8,9 +8,9 @@ from .inspect_gen import _detect_nans
 
 
 # TODO: deprecate `name` & `idx` for `identifier`? (i.e. both)
-def rnn_histogram(model, name=None, idx=None, layer=None, input_data=None,
-                  labels=None, mode='weights', equate_axes=1, data=None,
-                  configs=None, **kwargs):
+def rnn_histogram(model, _id, layer=None, input_data=None, labels=None,
+                  mode='weights', equate_axes=1, data=None, configs=None,
+                  **kwargs):
     """Plots histogram grid of RNN weights/gradients by kernel, gate (if gated),
        and direction (if bidirectional). Also detects NaNs and shows on plots.
 
@@ -204,8 +204,8 @@ def rnn_histogram(model, name=None, idx=None, layer=None, input_data=None,
 
     kw = _process_configs(configs, w, h, equate_axes)
     _catch_unknown_kwargs(kwargs)
-    data, rnn_info = _process_rnn_args(model, name, idx, layer, input_data,
-                                       labels, mode, data)
+    data, rnn_info = _process_rnn_args(model, _id, layer, input_data, labels,
+                                       mode, data)
     d = rnn_info
     gated_types  = ('LSTM', 'GRU', 'CuDNNLSTM', 'CuDNNGRU')
     kernel_types = ('KERNEL', 'RECURRENT')
@@ -247,9 +247,9 @@ def rnn_histogram(model, name=None, idx=None, layer=None, input_data=None,
     return subplots_figs, subplots_axes
 
 
-def rnn_heatmap(model, name=None, idx=None, layer=None, input_data=None,
-                labels=None, mode='weights', cmap='bwr',
-                norm='auto', data=None, configs=None, **kwargs):
+def rnn_heatmap(model, _id, layer=None, input_data=None, labels=None,
+                mode='weights', cmap='bwr', norm='auto', data=None,
+                configs=None, **kwargs):
     """Plots histogram grid of RNN weights/gradients by kernel, gate (if gated),
        and direction (if bidirectional). Also detects NaNs and prints in console.
 
@@ -444,8 +444,8 @@ def rnn_heatmap(model, name=None, idx=None, layer=None, input_data=None,
 
     _catch_unknown_kwargs(kwargs)
     kw = _process_configs(configs, w, h)
-    data, rnn_info = _process_rnn_args(model, name, idx, layer,
-                                       input_data, labels, mode, data, norm)
+    data, rnn_info = _process_rnn_args(model, _id, layer, input_data, labels,
+                                       mode, data, norm)
     d = rnn_info
     d['gate_sep_width'] = gate_sep_width
 

--- a/see_rnn/visuals_rnn.py
+++ b/see_rnn/visuals_rnn.py
@@ -7,7 +7,6 @@ from .utils import _process_rnn_args, _save_rnn_fig
 from .inspect_gen import _detect_nans
 
 
-# TODO: deprecate `name` & `idx` for `identifier`? (i.e. both)
 def rnn_histogram(model, _id, layer=None, input_data=None, labels=None,
                   mode='weights', equate_axes=1, data=None, configs=None,
                   **kwargs):
@@ -316,10 +315,6 @@ def rnn_heatmap(model, _id, layer=None, input_data=None, labels=None,
             'subtitle':  dict(weight='bold', fontsize=14),
             'xlabel':    dict(fontsize=12, weight='bold'),
             'ylabel':    dict(fontsize=12, weight='bold'),
-            'annot':     dict(fontsize=12, weight='bold',
-                              xy=(.90, .93), xycoords='axes fraction'),
-            'annot-nan': dict(fontsize=12, weight='bold', color='red',
-                              xy=(.05, .63), xycoords='axes fraction'),
             'colorbar':  dict(fraction=.03),
             'save':      dict(),
             }

--- a/see_rnn/visuals_rnn.py
+++ b/see_rnn/visuals_rnn.py
@@ -44,6 +44,12 @@ def rnn_histogram(model, _id, layer=None, input_data=None, labels=None,
               Ex: [1, 1] -> show both x- and y-ticks (and their labels).
                   [0, 0] -> hide both.
         bins: int. Pyplot `hist` kwarg: number of histogram bins per subplot.
+        savepath: str/None. Path to save resulting figure to. Also see `configs`.
+               If None, doesn't save.
+
+    Returns:
+        (subplots_figs, subplots_axes) of generated subplots. If layer is
+            bidirectional, len(subplots_figs) == 2, and latter's is also doubled.
     """
 
     w, h          = kwargs.get('w', 1), kwargs.get('h', 1)
@@ -296,6 +302,12 @@ def rnn_heatmap(model, _id, layer=None, input_data=None, labels=None,
         absolute_value: bool. If True, takes absolute value of all data before
               plotting. Works well with a greyscale `cmap` (e.g. None). Applied
               before `normalize`.
+        savepath: str/None. Path to save resulting figure to. Also see `configs`.
+               If None, doesn't save.
+
+    Returns:
+        (subplots_figs, subplots_axes) of generated subplots. If layer is
+            bidirectional, len(subplots_figs) == 2, and latter's is also doubled.
     """
 
     w, h           = kwargs.get('w', 1), kwargs.get('h', 1)

--- a/see_rnn/visuals_rnn.py
+++ b/see_rnn/visuals_rnn.py
@@ -316,7 +316,6 @@ def rnn_heatmap(model, name=None, idx=None, layer=None, input_data=None,
             'subtitle':  dict(weight='bold', fontsize=14),
             'xlabel':    dict(fontsize=12, weight='bold'),
             'ylabel':    dict(fontsize=12, weight='bold'),
-            'tight':     dict(),
             'annot':     dict(fontsize=12, weight='bold',
                               xy=(.90, .93), xycoords='axes fraction'),
             'annot-nan': dict(fontsize=12, weight='bold', color='red',
@@ -467,7 +466,7 @@ def rnn_heatmap(model, name=None, idx=None, layer=None, input_data=None,
             matrix_data = data[w_idx]
             _detect_and_print_nans(matrix_data, kernel_type, d)
 
-            is_vector = (len(matrix_data.shape) == 1)
+            is_vector = matrix_data.ndim == 1
             if is_vector:
                 matrix_data = np.expand_dims(matrix_data, -1)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,7 @@
 import os
+import tempfile
+import contextlib
+import shutil
 import tensorflow as tf
 
 
@@ -19,3 +22,18 @@ else:
     from keras.models import Model
     if USING_GPU:
         from keras.layers import CuDNNLSTM, CuDNNGRU
+
+
+@contextlib.contextmanager
+def tempdir(dirpath=None):
+    if dirpath is not None and os.path.isdir(dirpath):
+        shutil.rmtree(dirpath)
+        os.mkdir(dirpath)
+    elif dirpath is None:
+        dirpath = tempfile.mkdtemp()
+    else:
+        os.mkdir(dirpath)
+    try:
+        yield dirpath
+    finally:
+        shutil.rmtree(dirpath)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -11,7 +11,7 @@ from see_rnn import get_gradients, get_outputs, get_weights, get_rnn_weights
 from see_rnn import weights_norm
 from see_rnn import features_0D, features_1D, features_2D
 from see_rnn import features_hist, features_hist_v2
-from see_rnn import get_full_layer_name
+from see_rnn import get_full_name
 from see_rnn import rnn_summary
 from see_rnn import rnn_heatmap, rnn_histogram
 
@@ -86,7 +86,7 @@ def test_main():
 
 def _test_outputs(model):
     x, _ = make_data(K.int_shape(model.input), model.layers[2].units)
-    outs = get_outputs(model, x, layer_idx=1)
+    outs = get_outputs(model, x, idx=1)
     features_1D(outs[:1], show_y_zero=True)
     features_1D(outs[0])
     features_2D(outs)
@@ -95,8 +95,8 @@ def _test_outputs(model):
 def _test_outputs_gradients(model):
     x, y = make_data(K.int_shape(model.input), model.layers[2].units)
     name = model.layers[1].name
-    grads_all  = get_gradients(model, x, y, layer_name=name, mode='outputs')
-    grads_last = get_gradients(model, x, y, layer_idx=2,     mode='outputs')
+    grads_all  = get_gradients(model, x, y, name=name, mode='outputs')
+    grads_last = get_gradients(model, x, y, idx=2,     mode='outputs')
 
     kwargs1 = dict(n_rows=None, show_xy_ticks=[0, 0], show_borders=True,
                    max_timesteps=50, title_mode='grads')
@@ -120,20 +120,20 @@ def _test_weights_gradients(model):
     name = model.layers[1].name
     kws = dict(input_data=x, labels=y, mode='grads')
 
-    rnn_histogram(model, layer_name=name, bins=100, **kws)
-    rnn_heatmap(model,   layer_name=name,           **kws)
+    rnn_histogram(model, name=name, bins=100, **kws)
+    rnn_heatmap(model,   name=name,           **kws)
 
 
 def _test_weights(model):
     name = model.layers[1].name
-    rnn_histogram(model, layer_name=name, mode='weights', bins=100)
-    rnn_heatmap(model,   layer_name=name, mode='weights')
+    rnn_histogram(model, name=name, mode='weights', bins=100)
+    rnn_heatmap(model,   name=name, mode='weights')
 
 
 def _test_prefetched_data(model):
-    weights = get_rnn_weights(model, layer_idx=1)
-    rnn_histogram(model, layer_idx=1, data=weights)
-    rnn_heatmap(model,   layer_idx=1, data=weights)
+    weights = get_rnn_weights(model, idx=1)
+    rnn_histogram(model, idx=1, data=weights)
+    rnn_heatmap(model,   idx=1, data=weights)
 
 
 def make_model(rnn_layer, batch_shape, units=6, bidirectional=False,
@@ -230,7 +230,7 @@ def test_errors():  # test Exception cases
     x, y = make_data(batch_shape, units)
     model.train_on_batch(x, y)
 
-    grads = get_gradients(model, x, y, layer_idx=1)
+    grads = get_gradients(model, x, y, idx=1)
     grads_4D = np.expand_dims(grads, -1)
 
     from see_rnn.inspect_gen import get_layer, _make_grads_fn
@@ -240,27 +240,27 @@ def test_errors():  # test Exception cases
     pass_on_error(features_1D, grads_4D)
     pass_on_error(features_2D, grads_4D)
     pass_on_error(features_2D, grads)
-    pass_on_error(get_gradients, model, x, y, layer_idx=1, mode='cactus')
-    pass_on_error(get_gradients, model, x, y, layer_idx=1,
-                   layer_name='gru', layer=model.layers[1])
+    pass_on_error(get_gradients, model, x, y, idx=1, mode='cactus')
+    pass_on_error(get_gradients, model, x, y, idx=1,
+                   name='gru', layer=model.layers[1])
     pass_on_error(_make_grads_fn, model, model.layers[1], mode='banana')
     pass_on_error(features_hist, grads[:, :4, :3], po='tato')
     pass_on_error(features_hist_v2, grads[:, :4, :3], po='tato')
     pass_on_error(get_layer, model)
-    pass_on_error(get_layer, model, layer_name='capsule')
-    pass_on_error(rnn_heatmap, model, layer_idx=1, input_data=x, labels=y,
+    pass_on_error(get_layer, model, name='capsule')
+    pass_on_error(rnn_heatmap, model, idx=1, input_data=x, labels=y,
                    mode='coffee')
-    pass_on_error(rnn_heatmap, model, layer_idx=1, norm=(0, 1, 2))
-    pass_on_error(rnn_heatmap, model, layer_idx=1, mode='grads')
-    pass_on_error(rnn_histogram, model, layer_idx=1, norm=None)
+    pass_on_error(rnn_heatmap, model, idx=1, norm=(0, 1, 2))
+    pass_on_error(rnn_heatmap, model, idx=1, mode='grads')
+    pass_on_error(rnn_histogram, model, idx=1, norm=None)
     pass_on_error(rnn_heatmap, model, layer_index=9001)
     pass_on_error(features_0D, grads, cake='lie')
     pass_on_error(features_1D, grads, pup='not just any')
     pass_on_error(features_2D, grads, true=False)
-    outs = get_outputs(model, x, layer_idx=1)
-    pass_on_error(rnn_histogram, model, layer_idx=1, data=outs)
-    pass_on_error(rnn_histogram, model, layer_idx=1, data=[1])
-    pass_on_error(rnn_histogram, model, layer_idx=1, data=[[1]])
+    outs = get_outputs(model, x, idx=1)
+    pass_on_error(rnn_histogram, model, idx=1, data=outs)
+    pass_on_error(rnn_histogram, model, idx=1, data=[1])
+    pass_on_error(rnn_histogram, model, idx=1, data=[[1]])
     pass_on_error(features_hist, grads, co='vid')
 
     cprint("\n<< EXCEPTION TESTS PASSED >>\n", 'green')
@@ -281,7 +281,7 @@ def test_misc():  # test miscellaneous functionalities
     stats = weights_norm(model, 'gru')
     weights_norm(model, 'gru', _dict=stats)
 
-    grads = get_gradients(model, x, y, layer_idx=1)
+    grads = get_gradients(model, x, y, idx=1)
 
     features_1D(grads, subplot_samples=True, tight=True, borderwidth=2,
                 equate_axes=False)
@@ -294,27 +294,27 @@ def test_misc():  # test miscellaneous functionalities
                      show_borders=False, xlims=(-.01, .01), ylim=100,
                      borderwidth=1, show_xy_ticks=[0, 0], side_annot='row',
                      title="Grads")
-    rnn_histogram(model, layer_idx=1, show_xy_ticks=[0, 0], equate_axes=2)
-    rnn_heatmap(model, layer_idx=1, cmap=None, normalize=True, show_borders=False)
-    rnn_heatmap(model, layer_idx=1, cmap=None, norm='auto', absolute_value=True)
-    rnn_heatmap(model, layer_idx=1, norm=None)
-    rnn_heatmap(model, layer_idx=1, norm=(-.004, .004))
+    rnn_histogram(model, idx=1, show_xy_ticks=[0, 0], equate_axes=2)
+    rnn_heatmap(model, idx=1, cmap=None, normalize=True, show_borders=False)
+    rnn_heatmap(model, idx=1, cmap=None, norm='auto', absolute_value=True)
+    rnn_heatmap(model, idx=1, norm=None)
+    rnn_heatmap(model, idx=1, norm=(-.004, .004))
 
-    get_full_layer_name(model, name='gru')
-    get_full_layer_name(model, idx=1)
-    pass_on_error(get_full_layer_name, model, name='croc')
+    get_full_name(model, name='gru')
+    get_full_name(model, idx=1)
+    pass_on_error(get_full_name, model, name='croc')
 
-    get_weights(model, name='gru', as_list=False)
-    get_weights(model, name='gru', as_list=True)
+    get_weights(model, name='gru', as_dict=False)
+    get_weights(model, name='gru', as_dict=True)
     get_weights(model, name='gru/bias')
     pass_on_error(get_weights, model, name='gru/goo')
 
 
     from see_rnn.inspect_gen import get_layer, _detect_nans
 
-    get_layer(model, layer_name='gru')
-    get_rnn_weights(model, layer_idx=1, concat_gates=False, as_tensors=True)
-    rnn_heatmap(model, layer_idx=1, input_data=x, labels=y, mode='weights')
+    get_layer(model, name='gru')
+    get_rnn_weights(model, idx=1, concat_gates=False, as_tensors=True)
+    rnn_heatmap(model, idx=1, input_data=x, labels=y, mode='weights')
     _test_prefetched_data(model)
 
     # test NaN detection
@@ -323,8 +323,8 @@ def test_misc():  # test miscellaneous functionalities
 
     K.set_value(model.optimizer.lr, 1e12)
     train_model(model, iterations=10)
-    rnn_histogram(model, layer_idx=1)
-    rnn_heatmap(model, layer_idx=1)
+    rnn_histogram(model, idx=1)
+    rnn_heatmap(model, idx=1)
 
     del model
     reset_seeds(reset_graph_with_backend=K)
@@ -332,14 +332,14 @@ def test_misc():  # test miscellaneous functionalities
     # test SimpleRNN & other
     _model = make_model(SimpleRNN, batch_shape, units=128, use_bias=False)
     train_model(_model, iterations=1)  # TF2-Keras-Graph bug workaround
-    rnn_histogram(_model, layer_idx=1)  # test _pretty_hist
+    rnn_histogram(_model, idx=1)  # test _pretty_hist
     K.set_value(_model.optimizer.lr, 1e50)  # SimpleRNNs seem ridiculously robust
     train_model(_model, iterations=20)
-    rnn_heatmap(_model, layer_idx=1)
-    data = get_rnn_weights(_model, layer_idx=1)
-    rnn_heatmap(_model, layer_idx=1, input_data=x, labels=y, data=data)
+    rnn_heatmap(_model, idx=1)
+    data = get_rnn_weights(_model, idx=1)
+    rnn_heatmap(_model, idx=1, input_data=x, labels=y, data=data)
     os.environ["TF_KERAS"] = '0'
-    get_rnn_weights(_model, layer_idx=1, concat_gates=False)
+    get_rnn_weights(_model, idx=1, concat_gates=False)
     del _model
 
     assert True
@@ -383,16 +383,16 @@ def test_envs():  # pseudo-tests for coverage for different env flags
                            Model=Model)
         model = make_model(_GRU, batch_shape, new_imports=new_imports)
 
-        pass_on_error(model, x, y, layer_idx=1)  # possibly _backend-induced err
+        pass_on_error(model, x, y, idx=1)  # possibly _backend-induced err
         pass_on_error(glg, model, x, y, 1)
         rs(model.layers[1])
 
         from see_rnn.inspect_rnn import get_rnn_weights as grw
-        grw(model, layer_idx=1, concat_gates=False, as_tensors=True)
-        grw(model, layer_idx=1, concat_gates=False, as_tensors=False)
+        grw(model, idx=1, concat_gates=False, as_tensors=True)
+        grw(model, idx=1, concat_gates=False, as_tensors=False)
         _test_outputs(model)
         setattr(model.layers[2].cell, 'get_weights', None)
-        get_rnn_weights(model, layer_idx=2, concat_gates=True, as_tensors=False)
+        get_rnn_weights(model, idx=2, concat_gates=True, as_tensors=False)
 
         _model = _make_nonrnn_model()
         pass_on_error(_vrt, _model.layers[1])

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -254,6 +254,7 @@ def test_errors():  # test Exception cases
     pass_on_error(get_layer, model, 'capsule')
     pass_on_error(rnn_heatmap, model, 1, input_data=x, labels=y,
                    mode='coffee')
+    pass_on_error(rnn_heatmap, model, 1, co='vid')
     pass_on_error(rnn_heatmap, model, 1, norm=(0, 1, 2))
     pass_on_error(rnn_heatmap, model, 1, mode='grads')
     pass_on_error(rnn_histogram, model, 1, norm=None)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -262,7 +262,7 @@ def test_errors():  # test Exception cases
     pass_on_error(features_0D, grads, cake='lie')
     pass_on_error(features_1D, grads, pup='not just any')
     pass_on_error(features_2D, grads, true=False)
-    outs = get_outputs(model, x, idx=1)
+    outs = list(get_outputs(model, x, idx=1, as_dict=True).values())
     pass_on_error(rnn_histogram, model, idx=1, data=outs)
     pass_on_error(rnn_histogram, model, idx=1, data=[1])
     pass_on_error(rnn_histogram, model, idx=1, data=[[1]])
@@ -287,6 +287,7 @@ def test_misc():  # test miscellaneous functionalities
     weights_norm(model, 'gru', _dict=stats)
 
     grads = get_gradients(model, x, y, idx=1)
+    get_gradients(model, x, y, idx=1, as_dict=True)
 
     features_1D(grads, subplot_samples=True, tight=True, borderwidth=2,
                 equate_axes=False)
@@ -312,6 +313,8 @@ def test_misc():  # test miscellaneous functionalities
     with tempdir() as dirpath:
         rnn_histogram(model, idx=1, show_xy_ticks=[0, 0], equate_axes=2,
                       savepath=os.path.join(dirpath, 'img.png'))
+    rnn_histogram(model, idx=1, equate_axes=False,
+                  configs={'tight': dict(left=0, right=1)})
     rnn_heatmap(model, idx=1, cmap=None, normalize=True, show_borders=False)
     rnn_heatmap(model, idx=1, cmap=None, norm='auto', absolute_value=True)
     rnn_heatmap(model, idx=1, norm=None)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -7,6 +7,7 @@ from termcolor import cprint, colored
 from . import K
 from . import Input, LSTM, GRU, SimpleRNN, Bidirectional
 from . import Model
+from . import tempdir
 from see_rnn import get_gradients, get_outputs, get_weights, get_rnn_weights
 from see_rnn import weights_norm
 from see_rnn import features_0D, features_1D, features_2D
@@ -285,20 +286,34 @@ def test_misc():  # test miscellaneous functionalities
 
     features_1D(grads, subplot_samples=True, tight=True, borderwidth=2,
                 equate_axes=False)
-    features_1D(grads[0], subplot_samples=True)
+    with tempdir() as dirpath:
+        features_0D(grads[0], savepath=os.path.join(dirpath, 'img.png'))
+    with tempdir() as dirpath:
+        features_1D(grads[0], subplot_samples=True,
+                    savepath=os.path.join(dirpath, 'img.png'))
     features_2D(grads.T, n_rows=1.5, tight=True, borderwidth=2)
-    features_2D(grads.T[:, :, 0], norm='auto')
-    features_hist(grads, show_borders=False, borderwidth=1,
-                  show_xy_ticks=[0, 0], title="grads")
-    features_hist_v2(list(grads[:, :4, :3]), colnames=list('abcd'),
-                     show_borders=False, xlims=(-.01, .01), ylim=100,
-                     borderwidth=1, show_xy_ticks=[0, 0], side_annot='row',
-                     title="Grads")
-    rnn_histogram(model, idx=1, show_xy_ticks=[0, 0], equate_axes=2)
+    with tempdir() as dirpath:
+        features_2D(grads.T[:, :, 0], norm='auto',
+                    savepath=os.path.join(dirpath, 'img.png'))
+    with tempdir() as dirpath:
+        features_hist(grads, show_borders=False, borderwidth=1,
+                      show_xy_ticks=[0, 0], title="grads",
+                      savepath=os.path.join(dirpath, 'img.png'))
+    with tempdir() as dirpath:
+        features_hist_v2(list(grads[:, :4, :3]), colnames=list('abcd'),
+                         show_borders=False, xlims=(-.01, .01), ylim=100,
+                         borderwidth=1, show_xy_ticks=[0, 0], side_annot='row',
+                         title="Grads",
+                         savepath=os.path.join(dirpath, 'img.png'))
+    with tempdir() as dirpath:
+        rnn_histogram(model, idx=1, show_xy_ticks=[0, 0], equate_axes=2,
+                      savepath=os.path.join(dirpath, 'img.png'))
     rnn_heatmap(model, idx=1, cmap=None, normalize=True, show_borders=False)
     rnn_heatmap(model, idx=1, cmap=None, norm='auto', absolute_value=True)
     rnn_heatmap(model, idx=1, norm=None)
-    rnn_heatmap(model, idx=1, norm=(-.004, .004))
+    with tempdir() as dirpath:
+        rnn_heatmap(model, idx=1, norm=(-.004, .004),
+                    savepath=os.path.join(dirpath, 'img.png'))
 
     get_full_name(model, name='gru')
     get_full_name(model, idx=1)
@@ -309,9 +324,10 @@ def test_misc():  # test miscellaneous functionalities
     get_weights(model, name='gru/bias')
     pass_on_error(get_weights, model, name='gru/goo')
 
+    from see_rnn.utils import _filter_duplicates_by_keys
+    _filter_duplicates_by_keys(list('abbc'), tuple(np.random.randn(4, 20)))
 
     from see_rnn.inspect_gen import get_layer, _detect_nans
-
     get_layer(model, name='gru')
     get_rnn_weights(model, idx=1, concat_gates=False, as_tensors=True)
     rnn_heatmap(model, idx=1, input_data=x, labels=y, mode='weights')

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -273,7 +273,7 @@ def test_errors():  # test Exception cases
 
 def test_misc():  # test miscellaneous functionalities
     units = 6
-    batch_shape = (8, 100, 2*units)
+    batch_shape = (8, 100, 2 * units)
 
     reset_seeds(reset_graph_with_backend=K)
     model = make_model(GRU, batch_shape, activation='relu',
@@ -282,11 +282,14 @@ def test_misc():  # test miscellaneous functionalities
     model.train_on_batch(x, y)
 
     weights_norm(model, 'gru', omit_weight_names='bias', verbose=1)
+    weights_norm(model, ['gru', 1, (1, 1)])
     stats = weights_norm(model, 'gru')
     weights_norm(model, 'gru', _dict=stats)
 
     grads = get_gradients(model, 1, x, y)
     get_gradients(model, 1, x, y, as_dict=True)
+    get_gradients(model, ['gru', 1], x, y)
+    get_outputs(model, ['gru', 1], x)
 
     features_1D(grads, subplot_samples=True, tight=True, borderwidth=2,
                 equate_axes=False)
@@ -328,6 +331,7 @@ def test_misc():  # test miscellaneous functionalities
     get_weights(model, 'gru', as_dict=False)
     get_weights(model, 'gru', as_dict=True)
     get_weights(model, 'gru/bias')
+    get_weights(model, ['gru', 1, (1, 1)])
     pass_on_error(get_weights, model, 'gru/goo')
 
     from see_rnn.utils import _filter_duplicates_by_keys

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -297,14 +297,14 @@ def test_misc():  # test miscellaneous functionalities
     with tempdir() as dirpath:
         features_0D(grads[0], savepath=os.path.join(dirpath, 'img.png'))
     with tempdir() as dirpath:
-        features_1D(grads[0], subplot_samples=True,
+        features_1D(grads[0], subplot_samples=True, annotations=[1, 'pi'],
                     savepath=os.path.join(dirpath, 'img.png'))
     features_2D(grads.T, n_rows=1.5, tight=True, borderwidth=2)
     with tempdir() as dirpath:
         features_2D(grads.T[:, :, 0], norm='auto',
                     savepath=os.path.join(dirpath, 'img.png'))
     with tempdir() as dirpath:
-        features_hist(grads, show_borders=False, borderwidth=1,
+        features_hist(grads, show_borders=False, borderwidth=1, annotations=[0],
                       show_xy_ticks=[0, 0], title="grads",
                       savepath=os.path.join(dirpath, 'img.png'))
     with tempdir() as dirpath:

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -87,7 +87,7 @@ def test_main():
 
 def _test_outputs(model):
     x, _ = make_data(K.int_shape(model.input), model.layers[2].units)
-    outs = get_outputs(model, x, idx=1)
+    outs = get_outputs(model, 1, x)
     features_1D(outs[:1], show_y_zero=True)
     features_1D(outs[0])
     features_2D(outs)
@@ -96,8 +96,8 @@ def _test_outputs(model):
 def _test_outputs_gradients(model):
     x, y = make_data(K.int_shape(model.input), model.layers[2].units)
     name = model.layers[1].name
-    grads_all  = get_gradients(model, x, y, name=name, mode='outputs')
-    grads_last = get_gradients(model, x, y, idx=2,     mode='outputs')
+    grads_all  = get_gradients(model, name, x, y, mode='outputs')
+    grads_last = get_gradients(model, 2,    x, y, mode='outputs')
 
     kwargs1 = dict(n_rows=None, show_xy_ticks=[0, 0], show_borders=True,
                    max_timesteps=50, title_mode='grads')
@@ -125,20 +125,20 @@ def _test_weights_gradients(model):
         if hasattr(model.layers[1], 'backward_layer'):
             kws['savepath'] = dirpath
 
-        rnn_histogram(model, name=name, bins=100, **kws)
-        rnn_heatmap(model,   name=name,           **kws)
+        rnn_histogram(model, name, bins=100, **kws)
+        rnn_heatmap(model,   name,           **kws)
 
 
 def _test_weights(model):
     name = model.layers[1].name
-    rnn_histogram(model, name=name, mode='weights', bins=100)
-    rnn_heatmap(model,   name=name, mode='weights')
+    rnn_histogram(model, name, mode='weights', bins=100)
+    rnn_heatmap(model,   name, mode='weights')
 
 
 def _test_prefetched_data(model):
-    weights = get_rnn_weights(model, idx=1)
-    rnn_histogram(model, idx=1, data=weights)
-    rnn_heatmap(model,   idx=1, data=weights)
+    weights = get_rnn_weights(model, 1)
+    rnn_histogram(model, 1, data=weights)
+    rnn_heatmap(model,   1, data=weights)
 
 
 def make_model(rnn_layer, batch_shape, units=6, bidirectional=False,
@@ -235,7 +235,7 @@ def test_errors():  # test Exception cases
     x, y = make_data(batch_shape, units)
     model.train_on_batch(x, y)
 
-    grads = get_gradients(model, x, y, idx=1)
+    grads = get_gradients(model, 1, x, y)
     grads_4D = np.expand_dims(grads, -1)
 
     from see_rnn.inspect_gen import get_layer, _make_grads_fn
@@ -245,27 +245,26 @@ def test_errors():  # test Exception cases
     pass_on_error(features_1D, grads_4D)
     pass_on_error(features_2D, grads_4D)
     pass_on_error(features_2D, grads)
-    pass_on_error(get_gradients, model, x, y, idx=1, mode='cactus')
-    pass_on_error(get_gradients, model, x, y, idx=1,
-                   name='gru', layer=model.layers[1])
+    pass_on_error(get_gradients, model, 1, x, y, mode='cactus')
+    pass_on_error(get_gradients, model, 1, x, y, layer=model.layers[1])
     pass_on_error(_make_grads_fn, model, model.layers[1], mode='banana')
     pass_on_error(features_hist, grads[:, :4, :3], po='tato')
     pass_on_error(features_hist_v2, grads[:, :4, :3], po='tato')
     pass_on_error(get_layer, model)
-    pass_on_error(get_layer, model, name='capsule')
-    pass_on_error(rnn_heatmap, model, idx=1, input_data=x, labels=y,
+    pass_on_error(get_layer, model, 'capsule')
+    pass_on_error(rnn_heatmap, model, 1, input_data=x, labels=y,
                    mode='coffee')
-    pass_on_error(rnn_heatmap, model, idx=1, norm=(0, 1, 2))
-    pass_on_error(rnn_heatmap, model, idx=1, mode='grads')
-    pass_on_error(rnn_histogram, model, idx=1, norm=None)
+    pass_on_error(rnn_heatmap, model, 1, norm=(0, 1, 2))
+    pass_on_error(rnn_heatmap, model, 1, mode='grads')
+    pass_on_error(rnn_histogram, model, 1, norm=None)
     pass_on_error(rnn_heatmap, model, layer_index=9001)
     pass_on_error(features_0D, grads, cake='lie')
     pass_on_error(features_1D, grads, pup='not just any')
     pass_on_error(features_2D, grads, true=False)
-    outs = list(get_outputs(model, x, idx=1, as_dict=True).values())
-    pass_on_error(rnn_histogram, model, idx=1, data=outs)
-    pass_on_error(rnn_histogram, model, idx=1, data=[1])
-    pass_on_error(rnn_histogram, model, idx=1, data=[[1]])
+    outs = list(get_outputs(model, 1, x, as_dict=True).values())
+    pass_on_error(rnn_histogram, model, 1, data=outs)
+    pass_on_error(rnn_histogram, model, 1, data=[1])
+    pass_on_error(rnn_histogram, model, 1, data=[[1]])
     pass_on_error(features_hist, grads, co='vid')
 
     cprint("\n<< EXCEPTION TESTS PASSED >>\n", 'green')
@@ -286,8 +285,8 @@ def test_misc():  # test miscellaneous functionalities
     stats = weights_norm(model, 'gru')
     weights_norm(model, 'gru', _dict=stats)
 
-    grads = get_gradients(model, x, y, idx=1)
-    get_gradients(model, x, y, idx=1, as_dict=True)
+    grads = get_gradients(model, 1, x, y)
+    get_gradients(model, 1, x, y, as_dict=True)
 
     features_1D(grads, subplot_samples=True, tight=True, borderwidth=2,
                 equate_axes=False)
@@ -311,25 +310,25 @@ def test_misc():  # test miscellaneous functionalities
                          title="Grads",
                          savepath=os.path.join(dirpath, 'img.png'))
     with tempdir() as dirpath:
-        rnn_histogram(model, idx=1, show_xy_ticks=[0, 0], equate_axes=2,
+        rnn_histogram(model, 1, show_xy_ticks=[0, 0], equate_axes=2,
                       savepath=os.path.join(dirpath, 'img.png'))
-    rnn_histogram(model, idx=1, equate_axes=False,
+    rnn_histogram(model, 1, equate_axes=False,
                   configs={'tight': dict(left=0, right=1)})
-    rnn_heatmap(model, idx=1, cmap=None, normalize=True, show_borders=False)
-    rnn_heatmap(model, idx=1, cmap=None, norm='auto', absolute_value=True)
-    rnn_heatmap(model, idx=1, norm=None)
+    rnn_heatmap(model, 1, cmap=None, normalize=True, show_borders=False)
+    rnn_heatmap(model, 1, cmap=None, norm='auto', absolute_value=True)
+    rnn_heatmap(model, 1, norm=None)
     with tempdir() as dirpath:
-        rnn_heatmap(model, idx=1, norm=(-.004, .004),
+        rnn_heatmap(model, 1, norm=(-.004, .004),
                     savepath=os.path.join(dirpath, 'img.png'))
 
-    get_full_name(model, name='gru')
-    get_full_name(model, idx=1)
-    pass_on_error(get_full_name, model, name='croc')
+    get_full_name(model, 'gru')
+    get_full_name(model, 1)
+    pass_on_error(get_full_name, model, 'croc')
 
-    get_weights(model, name='gru', as_dict=False)
-    get_weights(model, name='gru', as_dict=True)
-    get_weights(model, name='gru/bias')
-    pass_on_error(get_weights, model, name='gru/goo')
+    get_weights(model, 'gru', as_dict=False)
+    get_weights(model, 'gru', as_dict=True)
+    get_weights(model, 'gru/bias')
+    pass_on_error(get_weights, model, 'gru/goo')
 
     from see_rnn.utils import _filter_duplicates_by_keys
     keys, data = _filter_duplicates_by_keys(list('abbc'), [1, 2, 3, 4])
@@ -341,9 +340,9 @@ def test_misc():  # test miscellaneous functionalities
     assert data[0] == [1, 2, 4] and data[1] == [5, 6, 8]
 
     from see_rnn.inspect_gen import get_layer, _detect_nans
-    get_layer(model, name='gru')
-    get_rnn_weights(model, idx=1, concat_gates=False, as_tensors=True)
-    rnn_heatmap(model, idx=1, input_data=x, labels=y, mode='weights')
+    get_layer(model, 'gru')
+    get_rnn_weights(model, 1, concat_gates=False, as_tensors=True)
+    rnn_heatmap(model, 1, input_data=x, labels=y, mode='weights')
     _test_prefetched_data(model)
 
     # test NaN detection
@@ -352,8 +351,8 @@ def test_misc():  # test miscellaneous functionalities
 
     K.set_value(model.optimizer.lr, 1e12)
     train_model(model, iterations=10)
-    rnn_histogram(model, idx=1)
-    rnn_heatmap(model, idx=1)
+    rnn_histogram(model, 1)
+    rnn_heatmap(model, 1)
 
     del model
     reset_seeds(reset_graph_with_backend=K)
@@ -361,14 +360,14 @@ def test_misc():  # test miscellaneous functionalities
     # test SimpleRNN & other
     _model = make_model(SimpleRNN, batch_shape, units=128, use_bias=False)
     train_model(_model, iterations=1)  # TF2-Keras-Graph bug workaround
-    rnn_histogram(_model, idx=1)  # test _pretty_hist
+    rnn_histogram(_model, 1)  # test _pretty_hist
     K.set_value(_model.optimizer.lr, 1e50)  # SimpleRNNs seem ridiculously robust
     train_model(_model, iterations=20)
-    rnn_heatmap(_model, idx=1)
-    data = get_rnn_weights(_model, idx=1)
-    rnn_heatmap(_model, idx=1, input_data=x, labels=y, data=data)
+    rnn_heatmap(_model, 1)
+    data = get_rnn_weights(_model, 1)
+    rnn_heatmap(_model, 1, input_data=x, labels=y, data=data)
     os.environ["TF_KERAS"] = '0'
-    get_rnn_weights(_model, idx=1, concat_gates=False)
+    get_rnn_weights(_model, 1, concat_gates=False)
     del _model
 
     assert True
@@ -412,16 +411,16 @@ def test_envs():  # pseudo-tests for coverage for different env flags
                            Model=Model)
         model = make_model(_GRU, batch_shape, new_imports=new_imports)
 
-        pass_on_error(model, x, y, idx=1)  # possibly _backend-induced err
+        pass_on_error(model, x, y, 1)  # possibly _backend-induced err
         pass_on_error(glg, model, x, y, 1)
         rs(model.layers[1])
 
         from see_rnn.inspect_rnn import get_rnn_weights as grw
-        grw(model, idx=1, concat_gates=False, as_tensors=True)
-        grw(model, idx=1, concat_gates=False, as_tensors=False)
+        grw(model, 1, concat_gates=False, as_tensors=True)
+        grw(model, 1, concat_gates=False, as_tensors=False)
         _test_outputs(model)
         setattr(model.layers[2].cell, 'get_weights', None)
-        get_rnn_weights(model, idx=2, concat_gates=True, as_tensors=False)
+        get_rnn_weights(model, 2, concat_gates=True, as_tensors=False)
 
         _model = _make_nonrnn_model()
         pass_on_error(_vrt, _model.layers[1])


### PR DESCRIPTION
**Features**:

 - Universal layer specifier, `_id`, that is a layer name, layer index, or list of either or of both
 - Support for figure saving on all visuals
 - `rnn_histogram` and `rnn_heatmap` now plot bias w/ kernel & recurrent kernel in one figure
 - All plots now return `fig` and `axes` objects

**Breaking**:

 - `layer_name` & `layer_idx` deprecated; `_id` now takes place of both, and can be a list containing both
 - `label_channels` in `features_1D` deprecated in favor of `annotations`

**Misc**:

 - Added tests
 - Updated docstrings
 - `K_eval` removed from `utils.py` (unused)
 - `_filter_duplicates_by_keys` added to `utils.py`
 - `_save_rnn_figs` added to `utils.py`