### PR TITLE
Add `as_tensors` kwarg to `get_weights`

### DIFF
--- a/see_rnn/inspect_gen.py
+++ b/see_rnn/inspect_gen.py
@@ -65,8 +65,8 @@ def get_outputs(model, _id, input_data, layer=None, learning_phase=0,
     return outs[0] if (one_requested and len(outs) == 1) else outs
 
 
-def get_gradients(model, _id, input_data, labels, layer=None, mode='outputs',
-                  sample_weights=None, learning_phase=0, as_dict=False):
+def get_gradients(model, _id, input_data, labels, sample_weights=None,
+                  learning_phase=0, layer=None, mode='outputs', as_dict=False):
     """Retrieves layer gradients w.r.t. outputs or weights.
     NOTE: gradients will be clipped if `clipvalue` or `clipnorm` were set.
 
@@ -87,14 +87,14 @@ def get_gradients(model, _id, input_data, labels, layer=None, mode='outputs',
                to be computed for the gradient.
         labels: np.ndarray & supported formats. Labels w.r.t. which loss is
                to be computed for the gradient.
-        layer: keras.Layer/tf.keras.Layer. Layer whose gradients to return.
-               Overrides `idx` and `name`.
-        mode: str. One of: 'outputs', 'weights'. If former, returns grads
-               w.r.t. layer outputs(2) - else, w.r.t. layer trainable weights.
         sample_weights: np.ndarray & supported formats. `sample_weight` kwarg
                to model.fit(), etc., weighting individual sample losses.
         learning_phase: bool. 1: use model in train mode
                               0: use model in inference mode
+        layer: keras.Layer/tf.keras.Layer. Layer whose gradients to return.
+               Overrides `idx` and `name`.
+        mode: str. One of: 'outputs', 'weights'. If former, returns grads
+               w.r.t. layer outputs(2) - else, w.r.t. layer trainable weights.
         as_dict: bool. True:  return gradient fullname-value pairs in a dict
                        False: return gradient values as list in order fetched
 

--- a/see_rnn/inspect_gen.py
+++ b/see_rnn/inspect_gen.py
@@ -99,7 +99,8 @@ def get_gradients(model, _id, input_data, labels, layer=None, mode='outputs',
                        False: return gradient values as list in order fetched
 
     Returns:
-        Layer weight gradients or gradient-value pairs (see `as_dict`).
+        Layer gradients or gradient-value pairs (see `as_dict`); gradients for
+        weights (if mode=='weights') or outputs (if mode=='outputs').
 
     (1): tf.data.Dataset, generators, .tfrecords, & other supported TensorFlow
          input data formats

--- a/see_rnn/visuals_gen.py
+++ b/see_rnn/visuals_gen.py
@@ -197,6 +197,18 @@ def features_1D(data, n_rows=None, annotations='auto', share_xy=(1, 1),
     savepath      = kwargs.get('savepath', None)
 
     def _process_configs(configs, w, h, tight, share_xy):
+        def _set_share_xy(kw, share_xy):
+            if isinstance(share_xy, (list, tuple)):
+                sharex, sharey = share_xy
+            else:
+                sharex = sharey = share_xy
+            if isinstance(sharex, int):
+                sharex = bool(sharex)
+            if isinstance(sharey, int):
+                sharey = bool(sharey)
+            kw['subplot']['sharex'] = sharex
+            kw['subplot']['sharey'] = sharey
+
         defaults = {
             'plot':    dict(),
             'subplot': dict(dpi=76, figsize=(10, 10)),
@@ -216,12 +228,7 @@ def features_1D(data, n_rows=None, annotations='auto', share_xy=(1, 1),
             defaults[key].update(configs.get(key, {}))
         kw = defaults.copy()
 
-        if isinstance(share_xy, (list, tuple)):
-            sharex, sharey = share_xy
-        else:
-            sharex = sharey = share_xy
-        kw['subplot']['sharex'] = sharex
-        kw['subplot']['sharey'] = sharey
+        _set_share_xy(kw, share_xy)
         size = kw['subplot']['figsize']
         kw['subplot']['figsize'] = (size[0] * w, size[1] * h)
         return kw
@@ -410,6 +417,18 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
     savepath      = kwargs.get('savepath', None)
 
     def _process_configs(configs, w, h, tight, share_xy):
+        def _set_share_xy(kw, share_xy):
+            if isinstance(share_xy, (list, tuple)):
+                sharex, sharey = share_xy
+            else:
+                sharex = sharey = share_xy
+            if isinstance(sharex, int):
+                sharex = bool(sharex)
+            if isinstance(sharey, int):
+                sharey = bool(sharey)
+            kw['subplot']['sharex'] = sharex
+            kw['subplot']['sharey'] = sharey
+
         defaults = {
             'plot':    dict(),
             'subplot': dict(dpi=76, figsize=(10, 10)),
@@ -428,12 +447,7 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
             defaults[key].update(configs.get(key, {}))
         kw = defaults.copy()
 
-        if isinstance(share_xy, (list, tuple)):
-            sharex, sharey = share_xy
-        else:
-            sharex = sharey = share_xy
-        kw['subplot']['sharex'] = sharex
-        kw['subplot']['sharey'] = sharey
+        _set_share_xy(kw, share_xy)
         size = kw['subplot']['figsize']
         kw['subplot']['figsize'] = (size[0] * w, size[1] * h)
         return kw
@@ -614,6 +628,18 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None,
     savepath      = kwargs.get('savepath', None)
 
     def _process_configs(configs, w, h, tight, share_xy):
+        def _set_share_xy(kw, share_xy):
+            if isinstance(share_xy, (list, tuple)):
+                sharex, sharey = share_xy
+            else:
+                sharex = sharey = share_xy
+            if isinstance(sharex, int):
+                sharex = bool(sharex)
+            if isinstance(sharey, int):
+                sharey = bool(sharey)
+            kw['subplot']['sharex'] = sharex
+            kw['subplot']['sharey'] = sharey
+
         defaults = {
             'plot':    dict(peaks_to_clip=0),
             'subplot': dict(dpi=76, figsize=(10, 10)),
@@ -633,12 +659,7 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None,
             defaults[key].update(configs.get(key, {}))
         kw = defaults.copy()
 
-        if isinstance(share_xy, (list, tuple)):
-            sharex, sharey = share_xy
-        else:
-            sharex = sharey = share_xy
-        kw['subplot']['sharex'] = sharex
-        kw['subplot']['sharey'] = sharey
+        _set_share_xy(kw, share_xy)
         size = kw['subplot']['figsize']
         kw['subplot']['figsize'] = (size[0] * w, size[1] * h)
         return kw
@@ -779,6 +800,18 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
     savepath      = kwargs.get('savepath', None)
 
     def _process_configs(configs, w, h, share_xy):
+        def _set_share_xy(kw, share_xy):
+            if isinstance(share_xy, (list, tuple)):
+                sharex, sharey = share_xy
+            else:
+                sharex = sharey = share_xy
+            if isinstance(sharex, int):
+                sharex = bool(sharex)
+            if isinstance(sharey, int):
+                sharey = bool(sharey)
+            kw['subplot']['sharex'] = sharex
+            kw['subplot']['sharey'] = sharey
+
         defaults = {
             'plot':    dict(peaks_to_clip=0),
             'subplot': dict(dpi=76, figsize=(10, 10)),
@@ -800,12 +833,7 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
             defaults[key].update(configs.get(key, {}))
         kw = defaults.copy()
 
-        if isinstance(share_xy, (list, tuple)):
-            sharex, sharey = share_xy
-        else:
-            sharex = sharey = share_xy
-        kw['subplot']['sharex'] = sharex
-        kw['subplot']['sharey'] = sharey
+        _set_share_xy(kw, share_xy)
         size = kw['subplot']['figsize']
         kw['subplot']['figsize'] = (size[0] * w, size[1] * h)
         return kw

--- a/see_rnn/visuals_gen.py
+++ b/see_rnn/visuals_gen.py
@@ -123,7 +123,7 @@ def features_0D(data, marker='o', cmap='bwr', color=None, configs=None, **kwargs
     return fig, axes
 
 
-def features_1D(data, n_rows=None, annotations='auto', equate_axes=True,
+def features_1D(data, n_rows=None, annotations='auto', share_xy=(1, 1),
                 max_timesteps=None, subplot_samples=False, configs=None,
                 **kwargs):
     """Plots 1D curves in a standalone graph or subplot grid.
@@ -140,7 +140,14 @@ def features_1D(data, n_rows=None, annotations='auto', equate_axes=True,
              list of str: annotate by indexing into the list.
                           If len(list) < len(data), won't annotate remainder.
              None: don't annotate.
-        equate_axes:    bool. If True, subplots will share x- and y-axes limits.
+        share_xy: bool/str/(tuple/list of bool/str) for (sharex, sharey)
+              kwargs passed to plt.subplots(). If bool/str, will use same
+              value for sharex & sharey.
+              - sharex: bool/str. True  -> subplots will share x-axes limits.
+                                  'col' -> limits shared along columns.
+                                  'row' -> limits shared along rows.
+                                  Overrides 'sharex' in `configs['subplot']`.
+              - sharey: bool/str. `sharex`, but for y-axis.
         max_timesteps:  int/None. Max number of timesteps to show per plot.
               If None, keeps original.
         subplot_samples: bool. If True, generates a subplot per dim 0 of `data`
@@ -189,10 +196,10 @@ def features_1D(data, n_rows=None, annotations='auto', equate_axes=True,
     color         = kwargs.get('color', None)
     savepath      = kwargs.get('savepath', None)
 
-    def _process_configs(configs, w, h, tight, equate_axes):
+    def _process_configs(configs, w, h, tight, share_xy):
         defaults = {
             'plot':    dict(),
-            'subplot': dict(sharex=True, sharey=True, dpi=76, figsize=(10, 10)),
+            'subplot': dict(dpi=76, figsize=(10, 10)),
             'title':   dict(weight='bold', fontsize=14, y=.93 + .12 * tight),
             'tight':   dict(left=0, right=1, bottom=0, top=1, wspace=0, hspace=0),
             'annot':   dict(weight='bold', fontsize=16, color='g',
@@ -209,8 +216,12 @@ def features_1D(data, n_rows=None, annotations='auto', equate_axes=True,
             defaults[key].update(configs.get(key, {}))
         kw = defaults.copy()
 
-        if not equate_axes:
-            kw['subplot'].update({'sharex': False, 'sharey': False})
+        if isinstance(share_xy, (list, tuple)):
+            sharex, sharey = share_xy
+        else:
+            sharex = sharey = share_xy
+        kw['subplot']['sharex'] = sharex
+        kw['subplot']['sharey'] = sharey
         size = kw['subplot']['figsize']
         kw['subplot']['figsize'] = (size[0] * w, size[1] * h)
         return kw
@@ -286,7 +297,7 @@ def features_1D(data, n_rows=None, annotations='auto', equate_axes=True,
         if not show_borders:
             ax.set_frame_on(False)
 
-    kw = _process_configs(configs, w, h, tight, equate_axes)
+    kw = _process_configs(configs, w, h, tight, share_xy)
     _catch_unknown_kwargs(kwargs)
     data = _process_data(data)
     n_rows, n_cols, color, annotations = _get_style_info(data, n_rows, color,
@@ -322,7 +333,8 @@ def features_1D(data, n_rows=None, annotations='auto', equate_axes=True,
 
 
 def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
-                timesteps_xaxis=True, max_timesteps=None, configs=None, **kwargs):
+                timesteps_xaxis=True, max_timesteps=None, share_xy=(1, 1),
+                configs=None, **kwargs):
     """Plots 2D heatmaps in a standalone graph or subplot grid.
 
     iter == list/tuple (both work)
@@ -347,6 +359,14 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
               if plotted along the x-axis.
         max_timesteps:  int/None. Max number of timesteps to show per plot.
               If None, keeps original.
+        share_xy: bool/str/(tuple/list of bool/str) for (sharex, sharey)
+              kwargs passed to plt.subplots(). If bool/str, will use same
+              value for sharex & sharey.
+              - sharex: bool/str. True  -> subplots will share x-axes limits.
+                                  'col' -> limits shared along columns.
+                                  'row' -> limits shared along rows.
+                                  Overrides 'sharex' in `configs['subplot']`.
+              - sharey: bool/str. `sharex`, but for y-axis.
         configs: dict. kwargs to customize various plot schemes:
             'plot':     passed to fig.hist(); fig = subplots figure
             'subplot':  passed to plt.subplots()
@@ -389,10 +409,10 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
     borderwidth   = kwargs.get('borderwidth', None)
     savepath      = kwargs.get('savepath', None)
 
-    def _process_configs(configs, w, h, tight):
+    def _process_configs(configs, w, h, tight, share_xy):
         defaults = {
             'plot':    dict(),
-            'subplot': dict(sharex=True, sharey=True, dpi=76, figsize=(10, 10)),
+            'subplot': dict(dpi=76, figsize=(10, 10)),
             'title':   dict(weight='bold', fontsize=14, y=.93 + .12 * tight),
             'tight':   dict(left=0, right=1, bottom=0, top=1, wspace=0, hspace=0),
             'colorbar': dict(),
@@ -408,6 +428,12 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
             defaults[key].update(configs.get(key, {}))
         kw = defaults.copy()
 
+        if isinstance(share_xy, (list, tuple)):
+            sharex, sharey = share_xy
+        else:
+            sharex = sharey = share_xy
+        kw['subplot']['sharex'] = sharex
+        kw['subplot']['sharey'] = sharey
         size = kw['subplot']['figsize']
         kw['subplot']['figsize'] = (size[0] * w, size[1] * h)
         return kw
@@ -480,7 +506,7 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
             ax.set_frame_on(False)
 
     _catch_unknown_kwargs(kwargs)
-    kw = _process_configs(configs, w, h, tight)
+    kw = _process_configs(configs, w, h, tight, share_xy)
     data = _process_data(data, max_timesteps, reflect_half,
                          timesteps_xaxis, channel_axis)
     n_rows, n_cols, vmin, vmax = _get_style_info(data, n_rows, norm)
@@ -525,7 +551,7 @@ def _get_nrows_and_ncols(n_rows, n_subplots):
 
 
 def features_hist(data, n_rows='vertical', bins=100, xlims=None,
-                  center_zero=False, tight=True, equate_axes=None,
+                  center_zero=False, tight=True, share_xy=('col', 1),
                   annotations='auto', configs=None, **kwargs):
     """Plots histograms in a subplot grid.
 
@@ -541,11 +567,14 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None,
               Overrides `xlims`.
         tight: bool. If True, plt.subplots_adjust (spacing) according to
               configs['tight'], defaulted to minimize intermediate padding.
-        equate_axes: bool. True ->  subplots will share x- and y-axes limits.
-                           False -> subplot limits will be independent.
-                           None -> leave defaults (sharex='col', sharey=True).
-                           If not None, will override `sharex` and `sharey` in
-                           `configs['subplot']`.
+        share_xy: bool/str/(tuple/list of bool/str) for (sharex, sharey)
+              kwargs passed to plt.subplots(). If bool/str, will use same
+              value for sharex & sharey.
+              - sharex: bool/str. True  -> subplots will share x-axes limits.
+                                  'col' -> limits shared along columns.
+                                  'row' -> limits shared along rows.
+                                  Overrides 'sharex' in `configs['subplot']`.
+              - sharey: bool/str. `sharex`, but for y-axis.
         annotations: str list/'auto'/None.
             'auto': annotate each subplot with its index.
              list of str: annotate by indexing into the list.
@@ -584,10 +613,10 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None,
     borderwidth   = kwargs.get('borderwidth', None)
     savepath      = kwargs.get('savepath', None)
 
-    def _process_configs(configs, w, h, tight, equate_axes):
+    def _process_configs(configs, w, h, tight, share_xy):
         defaults = {
             'plot':    dict(peaks_to_clip=0),
-            'subplot': dict(sharex='col', sharey=True, dpi=76, figsize=(10, 10)),
+            'subplot': dict(dpi=76, figsize=(10, 10)),
             'title':   dict(weight='bold', fontsize=14, y=.93 + .12 * tight),
             'tight':   dict(left=0, right=1, bottom=0, top=1, wspace=0, hspace=0),
             'annot':   dict(weight='bold', fontsize=14, xy=(.02, .7),
@@ -604,10 +633,12 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None,
             defaults[key].update(configs.get(key, {}))
         kw = defaults.copy()
 
-        if equate_axes is True:
-            kw['subplot'].update(dict(sharex=True, sharey=True))
-        elif equate_axes is False:
-            kw['subplot'].update(dict(sharex=False, sharey=False))
+        if isinstance(share_xy, (list, tuple)):
+            sharex, sharey = share_xy
+        else:
+            sharex = sharey = share_xy
+        kw['subplot']['sharex'] = sharex
+        kw['subplot']['sharey'] = sharey
         size = kw['subplot']['figsize']
         kw['subplot']['figsize'] = (size[0] * w, size[1] * h)
         return kw
@@ -650,7 +681,7 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None,
             ax.set_xlim(*xlims)
 
     _catch_unknown_kwargs(kwargs)
-    kw = _process_configs(configs, w, h, tight, equate_axes)
+    kw = _process_configs(configs, w, h, tight, share_xy)
     n_rows, n_cols, annotations = _get_style_info(data, n_rows, annotations)
     if center_zero and xlims is not None:
         print(NOTE, "`center_zero` will override `xlims`")
@@ -681,7 +712,7 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None,
 
 
 def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
-                     center_zero=False, tight=True, equate_axes=None,
+                     center_zero=False, tight=True, share_xy=('col', 1),
                      side_annot=None, configs=None, **kwargs):
     """Plots histograms in a subplot grid; tailored for multiple histograms
     per gridcell.
@@ -703,11 +734,14 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
         ylim: float. Top y limit of all subplots.
         tight: bool. If True, plt.subplots_adjust (spacing) according to
               configs['tight'], defaulted to minimize intermediate padding.
-        equate_axes: bool. True ->  subplots will share x- and y-axes limits.
-                           False -> subplot limits will be independent.
-                           None -> leave defaults (sharex='col', sharey=True).
-                           If not None, will override `sharex` and `sharey` in
-                           `configs['subplot']`.
+        share_xy: bool/str/(tuple/list of bool/str) for (sharex, sharey)
+              kwargs passed to plt.subplots(). If bool/str, will use same
+              value for sharex & sharey.
+              - sharex: bool/str. True  -> subplots will share x-axes limits.
+                                  'col' -> limits shared along columns.
+                                  'row' -> limits shared along rows.
+                                  Overrides 'sharex' in `configs['subplot']`.
+              - sharey: bool/str. `sharex`, but for y-axis.
         side_annot: str. Text to display to the right side of rightmost subplot
               boxes, enumerated by row number ({side_annot}{row})
         configs: dict. kwargs to customize various plot schemes:
@@ -744,10 +778,10 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
     borderwidth   = kwargs.get('borderwidth', None)
     savepath      = kwargs.get('savepath', None)
 
-    def _process_configs(configs, w, h, equate_axes):
+    def _process_configs(configs, w, h, share_xy):
         defaults = {
             'plot':    dict(peaks_to_clip=0),
-            'subplot': dict(sharex='col', sharey=True, dpi=76, figsize=(10, 10)),
+            'subplot': dict(dpi=76, figsize=(10, 10)),
             'title':   dict(weight='bold', fontsize=15, y=1.06),
             'tight':   dict(left=0, right=1, bottom=0, top=1,
                             wspace=.05, hspace=.05),
@@ -766,10 +800,12 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
             defaults[key].update(configs.get(key, {}))
         kw = defaults.copy()
 
-        if equate_axes is True:
-            kw['subplot'].update(dict(sharex=True, sharey=True))
-        elif equate_axes is False:
-            kw['subplot'].update(dict(sharex=False, sharey=False))
+        if isinstance(share_xy, (list, tuple)):
+            sharex, sharey = share_xy
+        else:
+            sharex = sharey = share_xy
+        kw['subplot']['sharex'] = sharex
+        kw['subplot']['sharey'] = sharey
         size = kw['subplot']['figsize']
         kw['subplot']['figsize'] = (size[0] * w, size[1] * h)
         return kw
@@ -809,7 +845,7 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
             ax.set_xlim(*xlims)
 
     _catch_unknown_kwargs(kwargs)
-    kw = _process_configs(configs, w, h, equate_axes)
+    kw = _process_configs(configs, w, h, share_xy)
     n_rows, n_cols = _get_data_info(data)
     if center_zero and xlims is not None:
         print(NOTE, "`center_zero` will override `xlims`")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,6 +16,7 @@ if TF_KERAS:
     from tensorflow.keras.layers import Input, LSTM, GRU
     from tensorflow.keras.layers import SimpleRNN, Bidirectional
     from tensorflow.keras.models import Model
+    from tensorflow.keras.regularizers import l1, l2, l1_l2
     if USING_GPU:
         from tensorflow.compat.v1.keras.layers import CuDNNLSTM, CuDNNGRU
 else:
@@ -23,6 +24,7 @@ else:
     from keras.layers import Input, LSTM, GRU
     from keras.layers import SimpleRNN, Bidirectional
     from keras.models import Model
+    from keras.regularizers import l1, l2, l1_l2
     if USING_GPU:
         from keras.layers import CuDNNLSTM, CuDNNGRU
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -11,7 +11,7 @@ from . import Input, LSTM, GRU, SimpleRNN, Bidirectional
 from . import Model
 from . import tempdir
 from see_rnn import get_gradients, get_outputs, get_weights, get_rnn_weights
-from see_rnn import weights_norm
+from see_rnn import weights_norm, _get_grads
 from see_rnn import features_0D, features_1D, features_2D
 from see_rnn import features_hist, features_hist_v2, hist_clipped
 from see_rnn import get_full_name
@@ -448,6 +448,7 @@ def test_envs():  # pseudo-tests for coverage for different env flags
 
         _model = _make_nonrnn_model()
         pass_on_error(_vrt, _model.layers[1])
+        pass_on_error(_get_grads(1, 2, 3, 4))
         del model, _model
 
     assert True

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -10,8 +10,9 @@ from . import K
 from . import Input, LSTM, GRU, SimpleRNN, Bidirectional
 from . import Model
 from . import tempdir
+from see_rnn.inspect_gen import _get_grads
 from see_rnn import get_gradients, get_outputs, get_weights, get_rnn_weights
-from see_rnn import weights_norm, _get_grads
+from see_rnn import weights_norm
 from see_rnn import features_0D, features_1D, features_2D
 from see_rnn import features_hist, features_hist_v2, hist_clipped
 from see_rnn import get_full_name

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -9,6 +9,7 @@ from termcolor import cprint, colored
 from . import K
 from . import Input, LSTM, GRU, SimpleRNN, Bidirectional
 from . import Model
+from . import l1_l2
 from . import tempdir
 from see_rnn.inspect_gen import _get_grads
 from see_rnn import get_gradients, get_outputs, get_weights, get_rnn_weights
@@ -144,90 +145,6 @@ def _test_prefetched_data(model):
     rnn_heatmap(model,   1, data=weights)
 
 
-def make_model(rnn_layer, batch_shape, units=6, bidirectional=False,
-               use_bias=True, activation='tanh', recurrent_dropout=0,
-               new_imports={}):
-    Input         = IMPORTS['Input']
-    Bidirectional = IMPORTS['Bidirectional']
-    Model         = IMPORTS['Model']
-    if new_imports != {}:
-        Input         = new_imports['Input']
-        Bidirectional = new_imports['Bidirectional']
-        Model         = new_imports['Model']
-
-    kw = {}
-    if not use_bias:
-        kw['use_bias'] = False     # for CuDNN or misc case
-    if activation == 'relu':
-        kw['activation'] = 'relu'  # for nan detection
-        kw['recurrent_dropout'] = recurrent_dropout
-
-    ipt = Input(batch_shape=batch_shape)
-    if bidirectional:
-        x = Bidirectional(rnn_layer(units, return_sequences=True, **kw))(ipt)
-    else:
-        x = rnn_layer(units, return_sequences=True, **kw)(ipt)
-    out = rnn_layer(units, return_sequences=False)(x)
-
-    model = Model(ipt, out)
-    model.compile('adam', 'mse')
-    return model
-
-
-def make_data(batch_shape, units):
-    return (np.random.randn(*batch_shape),
-            np.random.uniform(-1, 1, (batch_shape[0], units)))
-
-
-def train_model(model, iterations):
-    batch_shape = K.int_shape(model.input)
-    units = model.layers[2].units
-    x, y = make_data(batch_shape, units)
-
-    for i in range(iterations):
-        model.train_on_batch(x, y)
-        print(end='.')  # progbar
-        if i % 40 == 0:
-            x, y = make_data(batch_shape, units)
-
-
-def _make_nonrnn_model():
-    if os.environ.get("TF_KERAS", '0') == '1':
-        from tensorflow.keras.layers import Input, Dense
-        from tensorflow.keras.models import Model
-    else:
-        from keras.layers import Input, Dense
-        from keras.models import Model
-    ipt = Input((16,))
-    out = Dense(16)(ipt)
-    model = Model(ipt, out)
-    model.compile('adam', 'mse')
-    return model
-
-
-def reset_seeds(reset_graph_with_backend=None, verbose=1):
-    if reset_graph_with_backend is not None:
-        K = reset_graph_with_backend
-        K.clear_session()
-        tf.compat.v1.reset_default_graph()
-        if verbose:
-            print("KERAS AND TENSORFLOW GRAPHS RESET")
-
-    np.random.seed(1)
-    random.seed(2)
-    tf.compat.v1.set_random_seed(3)
-    if verbose:
-        print("RANDOM SEEDS RESET")
-
-
-def pass_on_error(func, *args, **kwargs):
-    try:
-        func(*args, **kwargs)
-    except BaseException as e:
-        print("Task Failed Successfully:", e)
-        pass
-
-
 def test_errors():  # test Exception cases
     units = 6
     batch_shape = (8, 100, 2*units)
@@ -302,7 +219,7 @@ def test_misc():  # test miscellaneous functionalities
     get_outputs(model, ['gru', 1], x)
 
     features_1D(grads, subplot_samples=True, tight=True, borderwidth=2,
-                equate_axes=False)
+                share_xy=False)
     with tempdir() as dirpath:
         features_0D(grads[0], savepath=os.path.join(dirpath, 'img.png'))
     with tempdir() as dirpath:
@@ -314,17 +231,17 @@ def test_misc():  # test miscellaneous functionalities
                     savepath=os.path.join(dirpath, 'img.png'))
     with tempdir() as dirpath:
         features_hist(grads, show_borders=False, borderwidth=1, annotations=[0],
-                      show_xy_ticks=[0, 0], equate_axes=True, title="grads",
-                      savepath=os.path.join(dirpath, 'img.png'))
+                      show_xy_ticks=[0, 0], share_xy=(1, 1),
+                      title="grads", savepath=os.path.join(dirpath, 'img.png'))
     with tempdir() as dirpath:
         features_hist_v2(list(grads[:, :4, :3]), colnames=list('abcd'),
                          show_borders=False, xlims=(-.01, .01), ylim=100,
                          borderwidth=1, show_xy_ticks=[0, 0], side_annot='row',
-                         equate_axes=True, title="Grads",
+                         share_xy=True, title="Grads",
                          savepath=os.path.join(dirpath, 'img.png'))
-    features_hist(grads, center_zero=True, xlims=(-1, 1), equate_axes=False)
+    features_hist(grads, center_zero=True, xlims=(-1, 1), share_xy=(0, 0))
     features_hist_v2(list(grads[:, :4, :3]), center_zero=True, xlims=(-1, 1),
-                     equate_axes=False)
+                     share_xy=(False, False))
     with tempdir() as dirpath:
         rnn_histogram(model, 1, show_xy_ticks=[0, 0], equate_axes=2,
                       savepath=os.path.join(dirpath, 'img.png'))
@@ -454,6 +371,104 @@ def test_envs():  # pseudo-tests for coverage for different env flags
 
     assert True
     cprint("\n<< ENV TESTS PASSED >>\n", 'green')
+
+
+def test_get_weight_penalties():
+    units = 6
+    batch_shape = (8, 100, 2 * units)
+
+    reset_seeds(reset_graph_with_backend=K)
+    model = make_model(GRU, batch_shape, activation='relu',
+                       recurrent_dropout=0.3)
+    x, y = make_data(batch_shape, units)
+    model.train_on_batch(x, y)
+
+
+def make_model(rnn_layer, batch_shape, units=6, bidirectional=False,
+               use_bias=True, activation='tanh', recurrent_dropout=0,
+               new_imports={}):
+    Input         = IMPORTS['Input']
+    Bidirectional = IMPORTS['Bidirectional']
+    Model         = IMPORTS['Model']
+    if new_imports != {}:
+        Input         = new_imports['Input']
+        Bidirectional = new_imports['Bidirectional']
+        Model         = new_imports['Model']
+
+    kw = {}
+    if not use_bias:
+        kw['use_bias'] = False     # for CuDNN or misc case
+    if activation == 'relu':
+        kw['activation'] = 'relu'  # for nan detection
+        kw['recurrent_dropout'] = recurrent_dropout
+    kw.update(dict(kernel_regularizer=l1_l2(1e-4),
+                   recurrent_regularizer=l1_l2(1e-4),
+                   bias_regularizer=l1_l2(1e-4)))
+
+    ipt = Input(batch_shape=batch_shape)
+    if bidirectional:
+        x = Bidirectional(rnn_layer(units, return_sequences=True, **kw))(ipt)
+    else:
+        x = rnn_layer(units, return_sequences=True, **kw)(ipt)
+    out = rnn_layer(units, return_sequences=False)(x)
+
+    model = Model(ipt, out)
+    model.compile('adam', 'mse')
+    return model
+
+
+def make_data(batch_shape, units):
+    return (np.random.randn(*batch_shape),
+            np.random.uniform(-1, 1, (batch_shape[0], units)))
+
+
+def train_model(model, iterations):
+    batch_shape = K.int_shape(model.input)
+    units = model.layers[2].units
+    x, y = make_data(batch_shape, units)
+
+    for i in range(iterations):
+        model.train_on_batch(x, y)
+        print(end='.')  # progbar
+        if i % 40 == 0:
+            x, y = make_data(batch_shape, units)
+
+
+def _make_nonrnn_model():
+    if os.environ.get("TF_KERAS", '0') == '1':
+        from tensorflow.keras.layers import Input, Dense
+        from tensorflow.keras.models import Model
+    else:
+        from keras.layers import Input, Dense
+        from keras.models import Model
+    ipt = Input((16,))
+    out = Dense(16)(ipt)
+    model = Model(ipt, out)
+    model.compile('adam', 'mse')
+    return model
+
+
+def reset_seeds(reset_graph_with_backend=None, verbose=1):
+    if reset_graph_with_backend is not None:
+        K = reset_graph_with_backend
+        K.clear_session()
+        tf.compat.v1.reset_default_graph()
+        if verbose:
+            print("KERAS AND TENSORFLOW GRAPHS RESET")
+
+    np.random.seed(1)
+    random.seed(2)
+    tf.compat.v1.set_random_seed(3)
+    if verbose:
+        print("RANDOM SEEDS RESET")
+
+
+def pass_on_error(func, *args, **kwargs):
+    try:
+        func(*args, **kwargs)
+    except BaseException as e:
+        print("Task Failed Successfully:", e)
+
 
 if __name__ == '__main__':
     os.environ['IS_MAIN'] = "1"

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -449,7 +449,7 @@ def test_envs():  # pseudo-tests for coverage for different env flags
 
         _model = _make_nonrnn_model()
         pass_on_error(_vrt, _model.layers[1])
-        pass_on_error(_get_grads(1, 2, 3, 4))
+        pass_on_error(_get_grads, 1, 2, 3, 4)
         del model, _model
 
     assert True


### PR DESCRIPTION
**FEATURES**:
 - Add `as_tensors` kwarg to `get_weights`
 - Deprecate `equate_axes` in `visuals_gen` for `share_xy`, directly setting `sharex` and `sharey`

**MISC**:
 - Improve `get_gradients` docstring
 - Change `get_gradients` arg ordering
