### PR TITLE
Improve `configs` defaults handling

### DIFF
--- a/see_rnn/utils.py
+++ b/see_rnn/utils.py
@@ -1,6 +1,33 @@
 import numpy as np
+from copy import deepcopy
 from pathlib import Path
+
 from ._backend import WARN, NOTE
+
+
+def _kw_from_configs(configs, defaults):
+    def _fill_absent_defaults(kw, defaults):
+        # override `defaults`, but keep those not in `configs`
+        for name, _dict in defaults.items():
+            if name not in kw:
+                kw[name] = _dict
+            else:
+                for k, v in _dict.items():
+                    if k not in kw[name]:
+                        kw[name][k] = v
+        return kw
+
+    configs = configs or {}
+    configs = deepcopy(configs)  # ensure external dict unchanged
+    for key in configs:
+        if key not in defaults:
+            raise ValueError(f"unexpected `configs` key: {key}; "
+                             "supported are: %s" % ', '.join(list(defaults)))
+
+    kw = deepcopy(configs)  # ensure external dict unchanged
+    # override `defaults`, but keep those not in `configs`
+    kw = _fill_absent_defaults(configs, defaults)
+    return kw
 
 
 def _validate_args(_id, layer=None):

--- a/see_rnn/visuals_gen.py
+++ b/see_rnn/visuals_gen.py
@@ -624,17 +624,6 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
             kw['subplot']['sharex'] = sharex
             kw['subplot']['sharey'] = sharey
 
-        def _fill_absent_defaults(kw, defaults):
-            # override `defaults`, but keep those not in `configs`
-            for name, _dict in defaults.items():
-                if name not in kw:
-                    kw[name] = _dict
-                else:
-                    for k, v in _dict.items():
-                        if k not in kw[name]:
-                            kw[name][k] = v
-            return kw
-
         defaults = {
             'plot':    dict(peaks_to_clip=0),
             'subplot': dict(dpi=76, figsize=(10, 10)),
@@ -819,17 +808,6 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
                 sharey = bool(sharey)
             kw['subplot']['sharex'] = sharex
             kw['subplot']['sharey'] = sharey
-
-        def _fill_absent_defaults(kw, defaults):
-            # override `defaults`, but keep those not in `configs`
-            for name, _dict in defaults.items():
-                if name not in kw:
-                    kw[name] = _dict
-                else:
-                    for k, v in _dict.items():
-                        if k not in kw[name]:
-                            kw[name][k] = v
-            return kw
 
         defaults = {
             'plot':    dict(peaks_to_clip=0),

--- a/see_rnn/visuals_gen.py
+++ b/see_rnn/visuals_gen.py
@@ -2,6 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import cm
 
+from .utils import _kw_from_configs
 from ._backend import NOTE
 
 
@@ -56,15 +57,8 @@ def features_0D(data, marker='o', cmap='bwr', color=None, configs=None, **kwargs
             'title': dict(weight='bold', fontsize=14),
             'save':  dict(),
             }
-        configs = configs or {}
-        for key in configs:
-            if key not in defaults:
-                raise ValueError(f"unexpected `configs` key: {key}; "
-                                 "supported are: %s" % ', '.join(list(defaults)))
-        # override defaults, but keep those not in `configs`
-        for key in defaults:
-            defaults[key].update(configs.get(key, {}))
-        kw = defaults.copy()
+        # deepcopy configs, and override defaults dicts or dict values
+        kw = _kw_from_configs(configs, defaults)
         return kw
 
     def _catch_unknown_kwargs(kwargs):
@@ -218,15 +212,8 @@ def features_1D(data, n_rows=None, annotations='auto', share_xy=(1, 1),
                             xy=(.03, .9), xycoords='axes fraction'),
             'save':    dict(),
             }
-        configs = configs or {}
-        for key in configs:
-            if key not in defaults:
-                raise ValueError(f"unexpected `configs` key: {key}; "
-                                 "supported are: %s" % ', '.join(list(defaults)))
-        # override defaults, but keep those not in `configs`
-        for key in defaults:
-            defaults[key].update(configs.get(key, {}))
-        kw = defaults.copy()
+        # deepcopy configs, and override defaults dicts or dict values
+        kw = _kw_from_configs(configs, defaults)
 
         _set_share_xy(kw, share_xy)
         size = kw['subplot']['figsize']
@@ -437,15 +424,8 @@ def features_2D(data, n_rows=None, norm=None, cmap='bwr', reflect_half=False,
             'colorbar': dict(),
             'save':     dict(),
             }
-        configs = configs or {}
-        for key in configs:
-            if key not in defaults:
-                raise ValueError(f"unexpected `configs` key: {key}; "
-                                 "supported are: %s" % ', '.join(list(defaults)))
-        # override defaults, but keep those not in `configs`
-        for key in defaults:
-            defaults[key].update(configs.get(key, {}))
-        kw = defaults.copy()
+        # deepcopy configs, and override defaults dicts or dict values
+        kw = _kw_from_configs(configs, defaults)
 
         _set_share_xy(kw, share_xy)
         size = kw['subplot']['figsize']
@@ -589,9 +569,9 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
                                   'row' -> limits shared along rows.
                                   Overrides 'sharex' in `configs['subplot']`.
               - sharey: bool/str. `sharex`, but for y-axis.
-        pad_xticks: bool/int. int-> kwarg to ax.tick_params(pad=). Move xticks
-                    above x-axis, and include only min/max shifted 10% inward.
-                    Useful for `tight`. If False/0, makes no change.
+        pad_xticks: bool/int. int-> kwarg to ax.tick_params(pad=). Pad xticks
+                    (<0 for above x-axis), and include only min/max shifted
+                    10% inward. Useful for `tight`. If False/0, makes no change.
                     If None and bool(`tight` and not `sharex`), defaults to -20.
         annotations: str list/'auto'/None.
             'auto': annotate each subplot with its index.
@@ -644,6 +624,17 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
             kw['subplot']['sharex'] = sharex
             kw['subplot']['sharey'] = sharey
 
+        def _fill_absent_defaults(kw, defaults):
+            # override `defaults`, but keep those not in `configs`
+            for name, _dict in defaults.items():
+                if name not in kw:
+                    kw[name] = _dict
+                else:
+                    for k, v in _dict.items():
+                        if k not in kw[name]:
+                            kw[name][k] = v
+            return kw
+
         defaults = {
             'plot':    dict(peaks_to_clip=0),
             'subplot': dict(dpi=76, figsize=(10, 10)),
@@ -653,15 +644,8 @@ def features_hist(data, n_rows='vertical', bins=100, xlims=None, tight=True,
                             xycoords='axes fraction', color='g'),
             'save': dict(),
             }
-        configs = configs or {}
-        for key in configs:
-            if key not in defaults:
-                raise ValueError(f"unexpected `configs` key: {key}; "
-                                 "supported are: %s" % ', '.join(list(defaults)))
-        # override defaults, but keep those not in `configs`
-        for key in defaults:
-            defaults[key].update(configs.get(key, {}))
-        kw = defaults.copy()
+        # deepcopy configs, and override defaults dicts or dict values
+        kw = _kw_from_configs(configs, defaults)
 
         _set_share_xy(kw, share_xy)
         size = kw['subplot']['figsize']
@@ -783,9 +767,9 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
                                   'row' -> limits shared along rows.
                                   Overrides 'sharex' in `configs['subplot']`.
               - sharey: bool/str. `sharex`, but for y-axis.
-        pad_xticks: bool/int. int-> kwarg to ax.tick_params(pad=). Move xticks
-                    above x-axis, and include only min/max shifted 10% inward.
-                    Useful for `tight`. If False/0, makes no change.
+        pad_xticks: bool/int. int-> kwarg to ax.tick_params(pad=). Pad xticks
+                    (<0 for above x-axis), and include only min/max shifted
+                    10% inward. Useful for `tight`. If False/0, makes no change.
                     If None and bool(`tight` and not `sharex`), defaults to -20.
         side_annot: str. Text to display to the right side of rightmost subplot
               boxes, enumerated by row number ({side_annot}{row})
@@ -836,6 +820,17 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
             kw['subplot']['sharex'] = sharex
             kw['subplot']['sharey'] = sharey
 
+        def _fill_absent_defaults(kw, defaults):
+            # override `defaults`, but keep those not in `configs`
+            for name, _dict in defaults.items():
+                if name not in kw:
+                    kw[name] = _dict
+                else:
+                    for k, v in _dict.items():
+                        if k not in kw[name]:
+                            kw[name][k] = v
+            return kw
+
         defaults = {
             'plot':    dict(peaks_to_clip=0),
             'subplot': dict(dpi=76, figsize=(10, 10)),
@@ -847,15 +842,8 @@ def features_hist_v2(data, colnames=None, bins=100, xlims=None, ylim=None,
                                xy=(1.02, .5), xycoords='axes fraction'),
             'save': dict(),
             }
-        configs = configs or {}
-        for key in configs:
-            if key not in defaults:
-                raise ValueError(f"unexpected `configs` key: {key}; "
-                                 "supported are: %s" % ', '.join(list(defaults)))
-        # override defaults, but keep those not in `configs`
-        for key in defaults:
-            defaults[key].update(configs.get(key, {}))
-        kw = defaults.copy()
+        # deepcopy configs, and override defaults dicts or dict values
+        kw = _kw_from_configs(configs, defaults)
 
         _set_share_xy(kw, share_xy)
         size = kw['subplot']['figsize']

--- a/see_rnn/visuals_rnn.py
+++ b/see_rnn/visuals_rnn.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from termcolor import colored
 
-from .utils import _process_rnn_args, _save_rnn_fig
+from .utils import _process_rnn_args, _kw_from_configs, _save_rnn_fig
 from .inspect_gen import detect_nans
 
 
@@ -80,11 +80,8 @@ def rnn_histogram(model, _id, layer=None, input_data=None, labels=None,
                               xy=(.05, .63), xycoords='axes fraction'),
             'save': dict(),
             }
-        configs = configs or {}
-        # override defaults, but keep those not in `configs`
-        for key in defaults:
-            defaults[key].update(configs.get(key, {}))
-        kw = defaults.copy()
+        # deepcopy configs, and override defaults dicts or dict values
+        kw = _kw_from_configs(configs, defaults)
 
         if not equate_axes:
             kw['subplot'].update({'sharex': False, 'sharey': False})
@@ -353,11 +350,8 @@ def rnn_heatmap(model, _id, layer=None, input_data=None, labels=None,
             'colorbar':  dict(fraction=.03),
             'save':      dict(),
             }
-        configs = configs or {}
-        # override defaults, but keep those not in `configs`
-        for key in defaults:
-            defaults[key].update(configs.get(key, {}))
-        kw = defaults.copy()
+        # deepcopy configs, and override defaults dicts or dict values
+        kw = _kw_from_configs(configs, defaults)
 
         size = kw['subplot']['figsize']
         kw['subplot']['figsize'] = (size[0] * w, size[1] * h)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -246,7 +246,8 @@ def test_misc():  # test miscellaneous functionalities
         rnn_histogram(model, 1, show_xy_ticks=[0, 0], equate_axes=2,
                       savepath=os.path.join(dirpath, 'img.png'))
     rnn_histogram(model, 1, equate_axes=False,
-                  configs={'tight': dict(left=0, right=1)})
+                  configs={'tight': dict(left=0, right=1),
+                           'plot': dict(color='red')})
     rnn_heatmap(model, 1, cmap=None, normalize=True, show_borders=False)
     rnn_heatmap(model, 1, cmap=None, norm='auto', absolute_value=True)
     rnn_heatmap(model, 1, norm=None)


### PR DESCRIPTION
**FEATURE**: in `visuals_gen` and `visuals_rnn`, `configs` will now keep values of dicts of `defaults`, unless specifying the same keys. E.g.:

```python
defaults = {'1': dict(a=1, b=2), '2': dict(c=3, d=4)}
configs  = {'1': dict(a=3, g=5)}
kw = {'1': {'a': 3, 'g': 5, 'b': 2}, '2': {'c': 3, 'd': 4}}  # AFTER
kw = {'1': {'a': 3, 'g': 5},         '2': {'c': 3, 'd': 4}}  # BEFORE
```
Also will apply `deepcopy(configs)` to not affect external dict.