### PR TITLE
Add Inf detection to NaN detection

### DIFF
--- a/see_rnn/__init__.py
+++ b/see_rnn/__init__.py
@@ -8,4 +8,4 @@ from .visuals_rnn import *
 from .inspect_gen import *
 from .inspect_rnn import *
 
-__version__ = '1.13.4'
+__version__ = '1.13.5'

--- a/see_rnn/inspect_gen.py
+++ b/see_rnn/inspect_gen.py
@@ -407,7 +407,7 @@ def detect_nans(data, include_inf=True):
     inf_txt = _get_txt(perc_inf,  data, 'Inf')
 
     if nan_txt and inf_txt:
-        txt = nan_txt + '\n' + inf_txt
+        txt = nan_txt + ', ' + inf_txt
     elif nan_txt:
         txt = nan_txt
     else:

--- a/see_rnn/inspect_gen.py
+++ b/see_rnn/inspect_gen.py
@@ -382,16 +382,36 @@ def get_weights(model, _id, omit_names=None, as_tensors=False, as_dict=False):
     return weights[0] if (len(_ids) == 1 and len(_ids) == 1) else weights
 
 
-def detect_nans(data):
+def detect_nans(data, include_inf=True):
+    def _get_txt(perc, data, name):
+        txt = ''
+        if perc > 0:
+            if perc < .1:
+                num = int((perc / 100) * data.size)  # show as quantity
+                txt = "{:d}% {}".format(num, name)
+            else:
+                txt = "{:.1f}% {}".format(perc, name)  # show as percent
+        return txt
+
     data = np.asarray(data)
     perc_nans = 100 * np.sum(np.isnan(data)) / data.size
-    if perc_nans == 0:
-        return None
-    if perc_nans < 0.1:
-        num_nans = int((perc_nans / 100) * data.size)  # show as quantity
-        txt = "{:d}% \nNaNs".format(num_nans)
+
+    if include_inf:
+        perc_inf = 100 * np.sum(np.isinf(data)) / data.size
     else:
-        txt = "{:.1f}% \nNaNs".format(perc_nans)  # show as percent
+        perc_inf = 0
+    if perc_nans == 0 and perc_inf == 0:
+        return None
+
+    nan_txt = _get_txt(perc_nans, data, 'NaN')
+    inf_txt = _get_txt(perc_inf,  data, 'Inf')
+
+    if nan_txt and inf_txt:
+        txt = nan_txt + '\n' + inf_txt
+    elif nan_txt:
+        txt = nan_txt
+    else:
+        txt = inf_txt
     return txt
 
 

--- a/see_rnn/visuals_rnn.py
+++ b/see_rnn/visuals_rnn.py
@@ -97,9 +97,11 @@ def rnn_histogram(model, _id, layer=None, input_data=None, labels=None,
                 raise Exception("unknown kwarg `%s`" % kwarg)
 
     def _detect_and_zero_nans(matrix_data):
-        nan_txt = detect_nans(matrix_data)
-        if nan_txt is not None:  # NaNs detected
+        nan_txt = detect_nans(matrix_data, include_inf=True)
+        if nan_txt is not None:  # NaN/Inf detected
             matrix_data[np.isnan(matrix_data)] = 0  # set NaNs to zero
+            matrix_data[np.isinf(matrix_data)] = 0  # set Infs to zero
+            nan_txt = '\n'.join(nan_txt.split(' '))  # reformat
         return matrix_data, nan_txt
 
     def _plot_bias(data, axes, direction_idx, bins, d, kw):
@@ -406,7 +408,6 @@ def rnn_heatmap(model, _id, layer=None, input_data=None, labels=None,
     def _print_nans(nan_txt, matrix_data, kernel_type, gate_names, rnn_dim):
         if gate_names[0] == '':
             print(kernel_type, end=":")
-            nan_txt = nan_txt.replace('\n', '')
             print(colored(nan_txt, 'red'))
         else:
             print('\n' + kernel_type + ":")
@@ -417,13 +418,12 @@ def rnn_heatmap(model, _id, layer=None, input_data=None, labels=None,
                 gates_data.append(matrix_data[..., start:end])
 
             for gate_name, gate_data in zip(gate_names, gates_data):
-                nan_txt = detect_nans(gate_data)
+                nan_txt = detect_nans(gate_data, include_inf=True)
                 if nan_txt is not None:
-                    nan_txt = nan_txt.replace('\n', '')
                     print(gate_name + ':', colored(nan_txt, 'red'))
 
     def _detect_and_print_nans(matrix_data, kernel_type, d):
-        nan_txt = detect_nans(matrix_data)
+        nan_txt = detect_nans(matrix_data, include_inf=True)
         if nan_txt is not None:
             _print_nans(nan_txt, matrix_data, kernel_type,
                         d['gate_names'], d['rnn_dim'])

--- a/see_rnn/visuals_rnn.py
+++ b/see_rnn/visuals_rnn.py
@@ -101,7 +101,10 @@ def rnn_histogram(model, _id, layer=None, input_data=None, labels=None,
         if nan_txt is not None:  # NaN/Inf detected
             matrix_data[np.isnan(matrix_data)] = 0  # set NaNs to zero
             matrix_data[np.isinf(matrix_data)] = 0  # set Infs to zero
-            nan_txt = '\n'.join(nan_txt.split(' '))  # reformat
+            if ', ' in nan_txt:
+                nan_txt = '\n'.join(nan_txt.split(', '))
+            else:
+                nan_txt = '\n'.join(nan_txt.split(' '))
         return matrix_data, nan_txt
 
     def _plot_bias(data, axes, direction_idx, bins, d, kw):

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -247,7 +247,8 @@ def test_misc():  # test miscellaneous functionalities
                       savepath=os.path.join(dirpath, 'img.png'))
     rnn_histogram(model, 1, equate_axes=False,
                   configs={'tight': dict(left=0, right=1),
-                            'plot': dict(color='red')})
+                           'plot':  dict(color='red'),
+                           'title': dict(fontsize=14),})
     rnn_heatmap(model, 1, cmap=None, normalize=True, show_borders=False)
     rnn_heatmap(model, 1, cmap=None, norm='auto', absolute_value=True)
     rnn_heatmap(model, 1, norm=None)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -288,9 +288,15 @@ def test_misc():  # test miscellaneous functionalities
     rnn_heatmap(model, 1, input_data=x, labels=y, mode='weights')
     _test_prefetched_data(model)
 
-    # test NaN detection
+    # test NaN/Inf detection
     nan_txt = detect_nans(np.array([1]*9999 + [np.nan])).replace('\n', ' ')
     print(nan_txt)  # case: print as quantity
+    data = np.array([np.nan, np.inf, -np.inf, 0])
+    print(detect_nans(data, include_inf=True))
+    print(detect_nans(data, include_inf=False))
+    data = np.array([np.inf, 0])
+    print(detect_nans(data, include_inf=True))
+    detect_nans(np.array([0]))
 
     K.set_value(model.optimizer.lr, 1e12)
     train_model(model, iterations=10)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -247,7 +247,7 @@ def test_misc():  # test miscellaneous functionalities
                       savepath=os.path.join(dirpath, 'img.png'))
     rnn_histogram(model, 1, equate_axes=False,
                   configs={'tight': dict(left=0, right=1),
-                           'plot': dict(color='red')})
+                            'plot': dict(color='red')})
     rnn_heatmap(model, 1, cmap=None, normalize=True, show_borders=False)
     rnn_heatmap(model, 1, cmap=None, norm='auto', absolute_value=True)
     rnn_heatmap(model, 1, norm=None)
@@ -310,7 +310,7 @@ def test_misc():  # test miscellaneous functionalities
     _model = make_model(SimpleRNN, batch_shape, units=128, use_bias=False)
     train_model(_model, iterations=1)  # TF2-Keras-Graph bug workaround
     rnn_histogram(_model, 1)  # test _pretty_hist
-    K.set_value(_model.optimizer.lr, 1e50)  # SimpleRNNs seem ridiculously robust
+    K.set_value(_model.optimizer.lr, 1e50)  # force NaNs
     train_model(_model, iterations=20)
     rnn_heatmap(_model, 1)
     data = get_rnn_weights(_model, 1)


### PR DESCRIPTION
**FEATURES**:
 - `detect_nans` now detects `np.inf` and `-np.inf` via `include_inf=True` (default), and prints as e.g. `25% NaN, 10% Inf`
 - `detect_nans` now returns text without a newline, e.g. `50% NaN` instead of `50%\nNaNs`

**BREAKING**:
 - `visuals_rnn` now pass `include_inf=True` to `detect_nans`

**MISC**:
 - Fixed possible redundant newline in `_print_nans`
 - `detect_nans` names nan `NaN` instead of `NaNs`