### PR TITLE
Change warn condition for `_id`, `layer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Will possibly implement:
  - [ ] Pytorch support
  - [ ] Interpretability visuals (e.g. saliency maps, adversarial attacks)
  - [ ] Tools for better probing backprop of `return_sequences=False`
+ - [ ] Unify `_id` and `layer`? Need duplicates resolution scheme
  
 ## Examples
 

--- a/see_rnn/__init__.py
+++ b/see_rnn/__init__.py
@@ -8,4 +8,4 @@ from .visuals_rnn import *
 from .inspect_gen import *
 from .inspect_rnn import *
 
-__version__ = '1.14.2'
+__version__ = '1.14.3'

--- a/see_rnn/utils.py
+++ b/see_rnn/utils.py
@@ -61,7 +61,7 @@ def _validate_args(_id, layer=None):
     def _one_requested(_ids, layer):
         return len(layer or _ids) == 1  # give `layer` precedence
 
-    if (_id is not None and layer is not None):
+    if _id and layer:
         print(WARN, "`layer` will override `_id`")
 
     _ids, layer = _ensure_list(_id, layer)

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ setup(
     license="MIT",
     author="OverLordGoldDragon",
     author_email="16495490+OverLordGoldDragon@users.noreply.github.com",
-    description=('RNN weights, gradients, & activations visualization '
-                 'in Keras & TensorFlow'),
+    description=("RNN and general weights, gradients, & activations "
+                 "visualization in Keras & TensorFlow"),
     long_description=read_file('README.md'),
     long_description_content_type="text/markdown",
     keywords=(


### PR DESCRIPTION
A warning would be thrown even if `_id=''` or is otherwise falsy, which is redundant.