### PR TITLE
Fix L1-norm case in `weights_norm`

### DIFF
--- a/see_rnn/__init__.py
+++ b/see_rnn/__init__.py
@@ -8,4 +8,4 @@ from .visuals_rnn import *
 from .inspect_gen import *
 from .inspect_rnn import *
 
-__version__ = '1.14.3'
+__version__ = '1.14.4'

--- a/see_rnn/inspect_gen.py
+++ b/see_rnn/inspect_gen.py
@@ -587,7 +587,7 @@ def weights_norm(model, _id, _dict=None, stat_fns=(np.max, np.mean),
             axis = axis if axis != -1 else len(w.shape) - 1
             reduction_axes = tuple([ax for ax in range(len(w.shape))
                                     if ax != axis])
-            if isinstance(norm_fn, tuple):
+            if isinstance(norm_fn, (tuple, list)):
                 outer_fn, inner_fn = norm_fn
                 return outer_fn(np.sum(inner_fn(w), axis=reduction_axes))
             else:

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -199,7 +199,7 @@ def test_misc():  # test miscellaneous functionalities
     model.train_on_batch(x, y, sw)
 
     weights_norm(model, 'gru', omit_names='bias', verbose=1)
-    weights_norm(model, ['gru', 1, (1, 1)])
+    weights_norm(model, ['gru', 1, (1, 1)], norm_fn=np.abs)
     stats = weights_norm(model, 'gru')
     weights_norm(model, 'gru', _dict=stats)
 


### PR DESCRIPTION
`norm_fn=np.abs` would compute L1 norm as: `np.sqrt(np.sum(np.abs(x)))`, which is incorrect; the sqrt is redundant. `norm_fn=np.abs` will now work correctly. L2-norm case always worked correctly.

For L2-norm, set `norm_fn = (np.sqrt, np.square) = (outer_fn, inner_fn)`, which will compute `outer_fn(sum(inner_fn(x)))`. Note that `norm_fn=np.square` will **no longer compute L2-norm correctly**.

Pardon the mishap.