### PR TITLE
Drop TF as requirement to allow general use

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,5 @@ coverage
 pytest
 pytest-cov
 pycodestyle
+tensorflow
 Keras

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 numpy
 matplotlib
-tensorflow

--- a/see_rnn/__init__.py
+++ b/see_rnn/__init__.py
@@ -22,13 +22,17 @@ def scalefig(fig):
 ##############################################################################
 
 from . import visuals_gen
-from . import visuals_rnn
-from . import inspect_gen
-from . import inspect_rnn
-
 from .visuals_gen import *
-from .visuals_rnn import *
-from .inspect_gen import *
-from .inspect_rnn import *
+try:
+    from . import visuals_rnn
+    from .visuals_rnn import *
+    from . import inspect_gen
+    from .inspect_gen import *
+    from . import inspect_rnn
+    from .inspect_rnn import *
+except:
+    # handled in _backend.py
+    pass
 
-__version__ = '1.15.0'
+
+__version__ = '1.15.1'

--- a/see_rnn/_backend.py
+++ b/see_rnn/_backend.py
@@ -2,8 +2,12 @@ import os
 from termcolor import colored
 
 
+TF_KERAS = os.environ.get("TF_KERAS", '1') == '1'
+WARN = colored("WARNING:", 'red')
+NOTE = colored("NOTE:", 'blue')
+
 try:
-    if os.environ.get("TF_KERAS", '1') == '1':
+    if TF_KERAS:
         from tensorflow.python.keras import backend as K
         from tensorflow.keras.layers import Layer
         from tensorflow.keras.models import Model
@@ -15,8 +19,3 @@ except:
     print("WARNING: failed to import TensorFlow or Keras; functionality "
           "is restricted to see_rnn.visuals_gen")
     K, Layer, Model = None, None, None
-
-
-TF_KERAS = os.environ.get("TF_KERAS", '1') == '1'
-WARN = colored("WARNING:", 'red')
-NOTE = colored("NOTE:", 'blue')

--- a/see_rnn/_backend.py
+++ b/see_rnn/_backend.py
@@ -2,17 +2,21 @@ import os
 from termcolor import colored
 
 
-TF_KERAS = os.environ.get("TF_KERAS", '1') == '1'
+try:
+    if os.environ.get("TF_KERAS", '1') == '1':
+        from tensorflow.python.keras import backend as K
+        from tensorflow.keras.layers import Layer
+        from tensorflow.keras.models import Model
+    else:
+        from keras import backend as K
+        from keras.layers import Layer
+        from keras.models import Model
+except:
+    print("WARNING: failed to import TensorFlow or Keras; functionality "
+          "is restricted to see_rnn.visuals_gen")
+    K, Layer, Model = None, None, None
 
+
+TF_KERAS = os.environ.get("TF_KERAS", '1') == '1'
 WARN = colored("WARNING:", 'red')
 NOTE = colored("NOTE:", 'blue')
-
-
-if TF_KERAS:
-    from tensorflow.python.keras import backend as K
-    from tensorflow.keras.layers import Layer
-    from tensorflow.keras.models import Model
-else:
-    from keras import backend as K
-    from keras.layers import Layer
-    from keras.models import Model

--- a/see_rnn/inspect_gen.py
+++ b/see_rnn/inspect_gen.py
@@ -479,7 +479,7 @@ def get_weights(model, _id, omit_names=None, as_tensors=False, as_dict=False):
     if as_dict:
         return weights
     weights = list(weights.values())
-    return weights[0] if len(_ids) == 1 else weights
+    return weights[0] if (len(_ids) == 1 and len(weights) == 1) else weights
 
 
 def detect_nans(data, include_inf=True):
@@ -664,7 +664,8 @@ def _get_layer_penalties(layer):
 
             if _lambda is not None:
                 weight_name = cell.weights[weight_idx].name
-                l1_l2 = (float(_lambda.l1), float(_lambda.l2))
+                l1_l2 = (float(getattr(_lambda, 'l1', 0)),
+                         float(getattr(_lambda, 'l2', 0)))
                 penalties.append([weight_name, l1_l2])
         return penalties
 

--- a/see_rnn/utils.py
+++ b/see_rnn/utils.py
@@ -1,9 +1,12 @@
 import numpy as np
-import tensorflow as tf
 from copy import deepcopy
 from pathlib import Path
-
 from ._backend import WARN, NOTE, TF_KERAS, Layer
+
+try:
+    import tensorflow as tf
+except:
+    pass  # handled in __init__ via _backend.py
 
 
 def _kw_from_configs(configs, defaults):

--- a/see_rnn/visuals_gen.py
+++ b/see_rnn/visuals_gen.py
@@ -2,8 +2,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import cm
 
-from .utils import _kw_from_configs, clipnums
 from ._backend import NOTE
+from .utils import _kw_from_configs, clipnums
 from . import scalefig
 
 


### PR DESCRIPTION
Only `see_rnn.visuals_gen` will work without TensorFlow