### PR TITLE
tf 2.5, keras functional api, tf.data.Dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# pycharm
+.idea

--- a/see_rnn/inspect_gen.py
+++ b/see_rnn/inspect_gen.py
@@ -2,14 +2,19 @@ import tensorflow as tf
 import numpy as np
 
 from copy import deepcopy
-from .utils import _validate_args, _get_params, _layer_of_output
+from .utils import (TF24plus, is_tensor, _validate_args, _get_params,
+                    _layer_of_output)
 from ._backend import K, TF_KERAS, Model
 
 if tf.executing_eagerly():
     from tensorflow.python.distribute import parameter_server_strategy
     from tensorflow.python.keras.engine import data_adapter
-    from tensorflow.keras.mixed_precision import (
-        LossScaleOptimizer as LossScaleOptimizer)
+    if TF24plus:
+        from tensorflow.keras.mixed_precision import LossScaleOptimizer
+    else:
+        from tensorflow.python.keras.mixed_precision.experimental import (
+            loss_scale_optimizer as lso)
+        LossScaleOptimizer = lso.LossScaleOptimizer
 
 
 def get_outputs(model, _id, input_data, layer=None, learning_phase=0,
@@ -276,13 +281,20 @@ def _get_grads_eager(model, input_data, labels, sample_weight=None,
                 strategy.extended,
                 parameter_server_strategy.ParameterServerStrategyExtended))
 
-        grads_and_vars = zip(gradients, _params)
-        if aggregate_grads_outside_optimizer:
-            grads_and_vars = optimizer._transform_unaggregated_gradients(grads_and_vars)
-            grads_and_vars = optimizer._aggregate_gradients(grads_and_vars)
-        grads_and_vars = optimizer._transform_gradients(grads_and_vars)
-
-        gradients = [g for g, _ in grads_and_vars]
+        if TF24plus:
+            grads_and_vars = zip(gradients, _params)
+            if aggregate_grads_outside_optimizer:
+                grads_and_vars = optimizer._transform_unaggregated_gradients(
+                    grads_and_vars)
+                grads_and_vars = optimizer._aggregate_gradients(grads_and_vars)
+            grads_and_vars = optimizer._transform_gradients(grads_and_vars)
+            gradients = [g for g, _ in grads_and_vars]
+        else:
+            if aggregate_grads_outside_optimizer:
+                gradients = optimizer._aggregate_gradients(zip(gradients, _params))
+            if isinstance(optimizer, lso.LossScaleOptimizer):
+                gradients = optimizer.get_unscaled_gradients(gradients)
+            gradients = optimizer._clip_gradients(gradients)
         return gradients
 
     if not tf.executing_eagerly():
@@ -294,7 +306,7 @@ def _get_grads_eager(model, input_data, labels, sample_weight=None,
     try:
         with tf.GradientTape() as tape:
             for p in params:
-                if tf.is_tensor(p):
+                if is_tensor(p):
                     _watch_layer_outputs(_layer_of_output(p), tape)
             y_pred = model(x, training=bool(learning_phase))
             loss = model.compiled_loss(y, y_pred, sample_weight,
@@ -305,7 +317,7 @@ def _get_grads_eager(model, input_data, labels, sample_weight=None,
         # ensure layer.call is restored to original
         # not guaranteed; can fail if program is forcibly interrupted
         for p in params:
-            if tf.is_tensor(p):
+            if is_tensor(p):
                 layer = _layer_of_output(p)
                 if hasattr(layer, 'call_orig'):
                     # may be False if `params` includes duplicates

--- a/see_rnn/inspect_gen.py
+++ b/see_rnn/inspect_gen.py
@@ -8,8 +8,8 @@ from ._backend import K, TF_KERAS, Model
 if tf.executing_eagerly():
     from tensorflow.python.distribute import parameter_server_strategy
     from tensorflow.python.keras.engine import data_adapter
-    from tensorflow.python.keras.mixed_precision.experimental import (
-        loss_scale_optimizer as lso)
+    from tensorflow.keras.mixed_precision import (
+        LossScaleOptimizer as LossScaleOptimizer)
 
 
 def get_outputs(model, _id, input_data, layer=None, learning_phase=0,
@@ -230,9 +230,12 @@ def _get_grads_eager(model, input_data, labels, sample_weight=None,
     then later reverted IF not interrupted.
     """
     def _process_input_data(x, y, sample_weight):
-        iterator = data_adapter.single_batch_iterator(model.distribute_strategy,
-                                                      x, y, sample_weight,
-                                                      class_weight=None)
+        if isinstance(input_data, tf.data.Dataset):
+            iterator = tf.compat.v1.data.make_one_shot_iterator(x)
+        else:
+            iterator = data_adapter.single_batch_iterator(model.distribute_strategy,
+                                                          x, y, sample_weight,
+                                                          class_weight=None)
         data = next(iterator)
         data = data_adapter.expand_1d(data)
         x, y, sample_weight = data_adapter.unpack_x_y_sample_weight(data)
@@ -261,7 +264,7 @@ def _get_grads_eager(model, input_data, labels, sample_weight=None,
 
     def _clip_and_scale_grads(strategy, tape, optimizer, loss, params):
         with tape:
-            if isinstance(optimizer, lso.LossScaleOptimizer):
+            if isinstance(optimizer, LossScaleOptimizer):
                 loss = optimizer.get_scaled_loss(loss)
 
         _params = [(p if isinstance(p, tf.Variable)
@@ -273,12 +276,13 @@ def _get_grads_eager(model, input_data, labels, sample_weight=None,
                 strategy.extended,
                 parameter_server_strategy.ParameterServerStrategyExtended))
 
+        grads_and_vars = zip(gradients, _params)
         if aggregate_grads_outside_optimizer:
-            gradients = optimizer._aggregate_gradients(zip(gradients, _params))
-        if isinstance(optimizer, lso.LossScaleOptimizer):
-            gradients = optimizer.get_unscaled_gradients(gradients)
+            grads_and_vars = optimizer._transform_unaggregated_gradients(grads_and_vars)
+            grads_and_vars = optimizer._aggregate_gradients(grads_and_vars)
+        grads_and_vars = optimizer._transform_gradients(grads_and_vars)
 
-        gradients = optimizer._clip_gradients(gradients)
+        gradients = [g for g, _ in grads_and_vars]
         return gradients
 
     if not tf.executing_eagerly():
@@ -290,7 +294,7 @@ def _get_grads_eager(model, input_data, labels, sample_weight=None,
     try:
         with tf.GradientTape() as tape:
             for p in params:
-                if isinstance(p, tf.Tensor):
+                if tf.is_tensor(p):
                     _watch_layer_outputs(_layer_of_output(p), tape)
             y_pred = model(x, training=bool(learning_phase))
             loss = model.compiled_loss(y, y_pred, sample_weight,
@@ -301,7 +305,7 @@ def _get_grads_eager(model, input_data, labels, sample_weight=None,
         # ensure layer.call is restored to original
         # not guaranteed; can fail if program is forcibly interrupted
         for p in params:
-            if isinstance(p, tf.Tensor):
+            if tf.is_tensor(p):
                 layer = _layer_of_output(p)
                 if hasattr(layer, 'call_orig'):
                     # may be False if `params` includes duplicates

--- a/see_rnn/utils.py
+++ b/see_rnn/utils.py
@@ -8,6 +8,8 @@ try:
 except:
     pass  # handled in __init__ via _backend.py
 
+TF24plus = bool(float(tf.__version__[:3]) > 2.3)
+
 
 def _kw_from_configs(configs, defaults):
     def _fill_absent_defaults(kw, defaults):
@@ -288,3 +290,8 @@ def _get_params(model, layers=None, params=None, mode='outputs', verbose=1):
             params = [w for l in layers for w in l.trainable_weights]
     params = _filter_params(params, verbose)
     return params
+
+
+def is_tensor(x):
+    return (tf.is_tensor(x) if TF24plus else
+            isinstance(x, tf.Tensor))

--- a/see_rnn/utils.py
+++ b/see_rnn/utils.py
@@ -246,7 +246,7 @@ def _get_params(model, layers=None, params=None, mode='outputs', verbose=1):
         def _to_omit(p):
             if isinstance(p, tf.Variable):  # param is layer weight
                 return False
-            elif isinstance(p, tf.Tensor):  # param is layer output
+            elif tf.is_tensor(p):  # param is layer output
                 layer = _layer_of_output(p)
                 if (TF_KERAS or tf.__version__[0] == '2'
                     ) and hasattr(layer, 'activation'):


### PR DESCRIPTION
Hello, this PR adds tensorflow 2.5.0 support with keras functional api. Also, input_data can be packed (input, labels) tf.data.Dataset. 

tf.data.Dataset example:
tf_dataset = tf.data.Dataset.from_generator(generator_func, output_types=output_types, output_shapes=output_shapes)
tf_dataset = tf_dataset.batch(16)
grads = get_gradients(model, 1, tf_dataset, None)

